### PR TITLE
chore(feat): Support Password as Type

### DIFF
--- a/pydantic_extra_types/__init__.py
+++ b/pydantic_extra_types/__init__.py
@@ -3,6 +3,7 @@ __version__ = '0.0.1'
 from pydantic_extra_types.types import (
     ABARoutingNumber,
     Color,
+    PasswordStr,
     CountryAlpha2,
     CountryAlpha3,
     CountryNumericCode,
@@ -25,4 +26,5 @@ __all__ = (
     'CountryNumericCode',
     'CountryOfficialName',
     'PhoneNumber',
+    'PasswordStr',
 )

--- a/pydantic_extra_types/types/__init__.py
+++ b/pydantic_extra_types/types/__init__.py
@@ -6,6 +6,7 @@ from pydantic_extra_types.types.country import (
     CountryOfficialName,
     CountryShortName,
 )
+from pydantic_extra_types.types.password import PasswordStr
 from pydantic_extra_types.types.payment import PaymentCardBrand, PaymentCardNumber
 from pydantic_extra_types.types.phone_numbers import PhoneNumber
 from pydantic_extra_types.types.routing_number import ABARoutingNumber
@@ -21,4 +22,5 @@ __all__ = (
     'CountryNumericCode',
     'CountryOfficialName',
     'PhoneNumber',
+    'PasswordStr',
 )

--- a/pydantic_extra_types/types/password.py
+++ b/pydantic_extra_types/types/password.py
@@ -1,0 +1,52 @@
+from typing import Any, ClassVar, Dict, Optional
+
+from pydantic_core import PydanticCustomError, core_schema
+from zxcvbn import zxcvbn
+
+
+class PasswordStr(str):
+    min_length: ClassVar[int] = 8
+    max_length: ClassVar[int] = 72
+    strip_whitespace: ClassVar[bool] = True
+    _password_strength: Optional[Dict[str, Any]] = None
+
+    def __new__(cls, password: str) -> 'PasswordStr':
+        return super().__new__(cls, password)
+
+    def __init__(self, password: str):
+        self.validate_length(password)
+        self._password_strength = zxcvbn(password)  # type: ignore
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.FunctionSchema:
+        return core_schema.function_after_schema(
+            core_schema.str_schema(
+                min_length=cls.min_length, max_length=cls.max_length, strip_whitespace=cls.strip_whitespace
+            ),
+            cls.validate,
+        )
+
+    @classmethod
+    def validate(cls, __input_value: str, **_kwargs: Any) -> 'PasswordStr':
+        return cls(__input_value)
+
+    @classmethod
+    def validate_length(cls, password: str) -> None:
+        if len(password) < cls.min_length:
+            raise PydanticCustomError(
+                'password_length',
+                'Password must be at least {min_length} characters',
+                {'min_length': cls.min_length},
+            )
+        if len(password) > cls.max_length:
+            raise PydanticCustomError(
+                'password_length',
+                'Password must be at most {max_length} characters',
+                {'max_length': cls.max_length},
+            )
+
+    @property
+    def strength(self) -> Dict[str, Any]:
+        if self._password_strength is None:
+            raise ValueError('Password strength not calculated')
+        return self._password_strength

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ classifiers = [
 requires-python = '>=3.7'
 dependencies = [
     'pydantic@git+https://github.com/pydantic/pydantic.git@main',
-    'phonenumbers'
+    'phonenumbers',
+    'zxcvbn',
 ]
 dynamic = ['version']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = '>=3.7'
 dependencies = [
     'pydantic@git+https://github.com/pydantic/pydantic.git@main',
     'phonenumbers',
-    'zxcvbn',
+    'zxcvbn >=4.4.25,<4.4.28',
 ]
 dynamic = ['version']
 

--- a/requirements/linting.in
+++ b/requirements/linting.in
@@ -5,3 +5,4 @@ black
 isort
 pyupgrade
 ruff
+types-zxcvbn

--- a/requirements/linting.txt
+++ b/requirements/linting.txt
@@ -50,7 +50,7 @@ tomli==2.0.1
     # via
     #   black
     #   mypy
-types-zxcvbn==4.4.1.3
+types-zxcvbn==4.4.1.4
     # via -r requirements/linting.in
 typing-extensions==4.5.0
     # via mypy

--- a/requirements/linting.txt
+++ b/requirements/linting.txt
@@ -50,6 +50,8 @@ tomli==2.0.1
     # via
     #   black
     #   mypy
+types-zxcvbn==4.4.1.3
+    # via -r requirements/linting.in
 typing-extensions==4.5.0
     # via mypy
 virtualenv==20.21.0

--- a/requirements/pyproject.txt
+++ b/requirements/pyproject.txt
@@ -16,5 +16,5 @@ typing-extensions==4.5.0
     # via
     #   pydantic
     #   pydantic-core
-zxcvbn==4.4.28
+zxcvbn==4.4.27
     # via pydantic-extra-types (pyproject.toml)

--- a/requirements/pyproject.txt
+++ b/requirements/pyproject.txt
@@ -16,3 +16,5 @@ typing-extensions==4.5.0
     # via
     #   pydantic
     #   pydantic-core
+zxcvbn==4.4.28
+    # via pydantic-extra-types (pyproject.toml)

--- a/tests/test_types_password.py
+++ b/tests/test_types_password.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+import pytest
+from pydantic_core import PydanticCustomError
+
+from pydantic import BaseModel
+from pydantic_extra_types import PasswordStr
+
+
+def test_password_str_length():
+    # Test password length validation
+    with pytest.raises(PydanticCustomError):
+        PasswordStr('short')
+    with pytest.raises(PydanticCustomError):
+        PasswordStr('x' * 73)
+
+    # Test valid password
+    p = PasswordStr('validpassword')
+    assert p == 'validpassword'
+
+
+def test_password_str_strength():
+    # Test password strength calculation
+    p = PasswordStr('weakpassword')
+    assert p.strength['score'] < 3
+
+    p = PasswordStr('strongpassword123')
+    assert p.strength['score'] >= 1
+
+
+class Data(BaseModel):
+    password: PasswordStr
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+
+    def __repr__(self) -> str:
+        return f'Data(password={self.password})'
+
+
+def test_password_str_model():
+    # Test password strength calculation
+    d = Data(password='weakpassword')
+    assert d.password.strength['score'] < 3
+    d = Data(password='strongpassword123')
+    assert d.password.strength['score'] >= 1


### PR DESCRIPTION
As we have this point before https://github.com/pydantic/pydantic/issues/5012

> - password type, can mostly used strip_whitespace and min_length, but also integrate with https://github.com/dwolfhub/zxcvbn-python ???

```py
from pydantic import BaseModel
from pydantic_extra_types import PasswordStr

class Data(BaseModel):
    password: PasswordStr

    def __init__(self, **data: Any):
        super().__init__(**data)

    def __repr__(self) -> str:
        return f'Data(password={self.password})'


def test_password():
    # Test password strength calculation
    d = Data(password='weakpassword')
    assert d.password.strength['score'] < 3

    d = Data(password='strongpassword123')
    assert d.password.strength['score'] >= 1
```