### PR TITLE
Fix Color JSON schema generation

### DIFF
--- a/pydantic_extra_types/types/color.py
+++ b/pydantic_extra_types/types/color.py
@@ -10,7 +10,7 @@ eg. Color((0, 255, 255)).as_named() == 'cyan' because "cyan" comes after "aqua".
 import math
 import re
 from colorsys import hls_to_rgb, rgb_to_hls
-from typing import Any, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 from pydantic_core import PydanticCustomError, core_schema
 
@@ -82,6 +82,10 @@ class Color(_repr.Representation):
 
         # if we've got here value must be a valid color
         self._original = value
+
+    @classmethod
+    def __pydantic_modify_json_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        field_schema.update(type='string', format='color')
 
     def original(self) -> ColorType:
         """

--- a/tests/test_types_color.py
+++ b/tests/test_types_color.py
@@ -219,3 +219,15 @@ def test_color_hashable():
     assert hash(Color('red')) != hash(Color('blue'))
     assert hash(Color('red')) == hash(Color((255, 0, 0)))
     assert hash(Color('red')) != hash(Color((255, 0, 0, 0.5)))
+
+
+def test_schema():
+    class Model(BaseModel):
+        color: Color
+
+    assert Model.model_json_schema() == {
+        'properties': {'color': {'format': 'color', 'title': 'Color', 'type': 'string'}},
+        'required': ['color'],
+        'title': 'Model',
+        'type': 'object',
+    }


### PR DESCRIPTION
Addresses my comment on #20.

Note that with the change from #20, if you try to generate a JSON schema for a model with a field of type Color, it actually errors:

```
pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.FunctionSchema (<bound method Color._validate of <class 'pydantic_extra_types.types.color.Color'>>)
```