### PR TITLE
Add support for transparent Color

### DIFF
--- a/pydantic_extra_types/color.py
+++ b/pydantic_extra_types/color.py
@@ -291,6 +291,7 @@ def parse_str(value: str) -> RGBA:
     * hex long eg. `<prefix>ffffff` (prefix can be `#`, `0x` or nothing)
     * `rgb(<r>, <g>, <b>)`
     * `rgba(<r>, <g>, <b>, <a>)`
+    * `transparent`
 
     Args:
         value: A string representing a color.
@@ -336,6 +337,9 @@ def parse_str(value: str) -> RGBA:
     m = re.fullmatch(r_hsl, value_lower) or re.fullmatch(r_hsl_v4_style, value_lower)
     if m:
         return parse_hsl(*m.groups())  # type: ignore
+
+    if value_lower == 'transparent':
+        return RGBA(0, 0, 0, 0)
 
     raise PydanticCustomError(
         'color_error',

--- a/tests/test_types_color.py
+++ b/tests/test_types_color.py
@@ -13,6 +13,7 @@ from pydantic_extra_types.color import Color
         # named colors
         ('aliceblue', (240, 248, 255)),
         ('Antiquewhite', (250, 235, 215)),
+        ('transparent', (0, 0, 0, 0)),
         ('#000000', (0, 0, 0)),
         ('#DAB', (221, 170, 187)),
         ('#dab', (221, 170, 187)),


### PR DESCRIPTION
Implementation of #58 

---

I opted not to put it in the existing `COLORS_BY_NAME` dictionary as these are all RGB values, and this requires RGBA values. This would then require adding a fourth `None` value to all the tuples, adjusting all that logic, etc.; and that seems overkill for this single color.