### PR TITLE
Fix mac adddress validation

### DIFF
--- a/pydantic_extra_types/mac_address.py
+++ b/pydantic_extra_types/mac_address.py
@@ -54,7 +54,7 @@ class MacAddress(str):
                 {'mac_address': value.decode(), 'required_length': 14},
             )
 
-        if value[2] == ord(':') or value[2] == ord('-'):
+        if value[2] in [ord(':'), ord('-')]:
             if (len(value) + 1) % 3 != 0:
                 raise PydanticCustomError(
                     'invalid MAC address', 'Must have the format xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx'

--- a/pydantic_extra_types/mac_address.py
+++ b/pydantic_extra_types/mac_address.py
@@ -22,85 +22,84 @@ class MacAddress(str):
     Represents a mac address - IEEE 802 MAC-48, EUI-48, EUI-64, or a 20-octet
     """
 
-    __slots__ = '_mac_address'
-
-    def __init__(self, value: MacAddressType) -> None:
-        self._mac_address: str
-        if isinstance(value, bytes):
-            self._mac_address = validate_mac_address(value)
-        elif isinstance(value, str):
-            self._mac_address = validate_mac_address(value.encode())
-        else:
-            raise PydanticCustomError(
-                'mac_address_error',
-                'value is not a valid Mac Address: value must be a string or bytes',
-            )
-
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
-        return core_schema.general_after_validator_function(
+        return core_schema.general_before_validator_function(
             cls._validate,
             core_schema.str_schema(),
         )
 
     @classmethod
-    def _validate(cls, __input_value: Any, _: Any) -> MacAddress:
-        return cls(__input_value)
+    def _validate(cls, __input_value: str, _: Any) -> str:
+        _mac_address = cls.validate_mac_address(__input_value.encode())
+        return _mac_address
 
+    @staticmethod
+    def validate_mac_address(value: bytes) -> str:
+        """
+        Validate a Mac Address from the provided byte value.
 
-def validate_mac_address(value: bytes) -> str:
-    """
-    Validate a Mac Address from the provided byte value.
+        Args:
+            value (bytes): The byte value representing the Mac Address.
 
-    Args:
-        value (bytes): The byte value representing the Mac Address.
+        Returns:
+            str: The parsed Mac Address as a string.
 
-    Returns:
-        str: The parsed Mac Address as a string.
-
-    Raises:
-        PydanticCustomError: If the value is not a valid Mac Address.
-    """
-    if len(value) < 14:
-        raise PydanticCustomError(
-            'mac_address_len',
-            'Length for a {mac_address} mac address must be {required_length}',
-            {'mac_address': value.decode(), 'required_length': 14},
-        )
-
-    if value[2] in [ord(':'), ord('-')]:
-        if (len(value) + 1) % 3 != 0:
+        Raises:
+            PydanticCustomError: If the value is not a valid Mac Address.
+        """
+        if len(value) < 14:
             raise PydanticCustomError(
-                'mac_address_format', 'Must have the format xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx'
+                'invalid MAC address',
+                'Length for a {mac_address} MAC address must be {required_length}',
+                {'mac_address': value.decode(), 'required_length': 14},
             )
-        n = (len(value) + 1) // 3
-    elif value[4] == ord('.'):
-        if (len(value) + 1) % 5 != 0:
-            raise PydanticCustomError('mac_address_format', 'Must have the format xx.xx.xx.xx.xx.xx')
-        n = 2 * (len(value) + 1) // 5
-    else:
-        raise PydanticCustomError('mac_address_format', 'Unrecognized format')
 
-    if n not in (6, 8, 20):
-        raise PydanticCustomError(
-            'mac_address_len',
-            'Length for a {mac_address}  mac address must be {required_length}',
-            {'mac_address': value.decode(), 'required_length': (6, 8, 20)},
-        )
+        if value[2] == ord(':') or value[2] == ord('-'):
+            if (len(value) + 1) % 3 != 0:
+                raise PydanticCustomError(
+                    'invalid MAC address', 'Must have the format xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx'
+                )
+            n = (len(value) + 1) // 3
+            if n not in (6, 8, 20):
+                raise PydanticCustomError(
+                    'invalid MAC address',
+                    'Length for a {mac_address} MAC address must be {required_length}',
+                    {'mac_address': value.decode(), 'required_length': (6, 8, 20)},
+                )
+            mac_address = bytearray(n)
+            x = 0
+            for i in range(n):
+                try:
+                    byte_value = int(value[x : x + 2], 16)
+                    mac_address[i] = byte_value
+                    x += 3
+                except ValueError as e:
+                    raise PydanticCustomError('invalid MAC address', 'Unrecognized format') from e
 
-    hw = bytearray(n)
-    x = 0
-    for i in range(0, n, 2):
-        try:
-            byte_value = int(value[x : x + 2], 16)
-            hw[i] = byte_value
-            if value[4] == ord('.'):
-                byte_value = int(value[x + 2 : x + 4], 16)
-                hw[i + 1] = byte_value
-                x += 5
-            else:
-                x += 3
-        except ValueError as e:
-            raise PydanticCustomError('mac_address_format', 'Unrecognized format') from e
+        elif value[4] == ord('.'):
+            if (len(value) + 1) % 5 != 0:
+                raise PydanticCustomError('invalid MAC address', 'Must have the format xx.xx.xx.xx.xx.xx')
+            n = 2 * (len(value) + 1) // 5
+            if n not in (6, 8, 20):
+                raise PydanticCustomError(
+                    'invalid MAC address',
+                    'Length for a {mac_address} MAC address must be {required_length}',
+                    {'mac_address': value.decode(), 'required_length': (6, 8, 20)},
+                )
+            mac_address = bytearray(n)
+            x = 0
+            for i in range(0, n, 2):
+                try:
+                    byte_value = int(value[x : x + 2], 16)
+                    mac_address[i] = byte_value
+                    byte_value = int(value[x + 2 : x + 4], 16)
+                    mac_address[i + 1] = byte_value
+                    x += 5
+                except ValueError as e:
+                    raise PydanticCustomError('invalid MAC address', 'Unrecognized format') from e
 
-    return ':'.join(f'{b:02x}' for b in hw)
+        else:
+            raise PydanticCustomError('invalid MAC address', 'Unrecognized format')
+
+        return ':'.join(f'{b:02x}' for b in mac_address)

--- a/pydantic_extra_types/mac_address.py
+++ b/pydantic_extra_types/mac_address.py
@@ -31,8 +31,7 @@ class MacAddress(str):
 
     @classmethod
     def _validate(cls, __input_value: str, _: Any) -> str:
-        _mac_address = cls.validate_mac_address(__input_value.encode())
-        return _mac_address
+        return cls.validate_mac_address(__input_value.encode())
 
     @staticmethod
     def validate_mac_address(value: bytes) -> str:

--- a/pydantic_extra_types/mac_address.py
+++ b/pydantic_extra_types/mac_address.py
@@ -49,7 +49,7 @@ class MacAddress(str):
         """
         if len(value) < 14:
             raise PydanticCustomError(
-                'invalid MAC address',
+                'mac_address_len',
                 'Length for a {mac_address} MAC address must be {required_length}',
                 {'mac_address': value.decode(), 'required_length': 14},
             )
@@ -57,12 +57,12 @@ class MacAddress(str):
         if value[2] in [ord(':'), ord('-')]:
             if (len(value) + 1) % 3 != 0:
                 raise PydanticCustomError(
-                    'invalid MAC address', 'Must have the format xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx'
+                    'mac_address_format', 'Must have the format xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx'
                 )
             n = (len(value) + 1) // 3
             if n not in (6, 8, 20):
                 raise PydanticCustomError(
-                    'invalid MAC address',
+                    'mac_address_format',
                     'Length for a {mac_address} MAC address must be {required_length}',
                     {'mac_address': value.decode(), 'required_length': (6, 8, 20)},
                 )
@@ -74,15 +74,15 @@ class MacAddress(str):
                     mac_address[i] = byte_value
                     x += 3
                 except ValueError as e:
-                    raise PydanticCustomError('invalid MAC address', 'Unrecognized format') from e
+                    raise PydanticCustomError('mac_address_format', 'Unrecognized format') from e
 
         elif value[4] == ord('.'):
             if (len(value) + 1) % 5 != 0:
-                raise PydanticCustomError('invalid MAC address', 'Must have the format xx.xx.xx.xx.xx.xx')
+                raise PydanticCustomError('mac_address_format', 'Must have the format xx.xx.xx.xx.xx.xx')
             n = 2 * (len(value) + 1) // 5
             if n not in (6, 8, 20):
                 raise PydanticCustomError(
-                    'invalid MAC address',
+                    'mac_address_format',
                     'Length for a {mac_address} MAC address must be {required_length}',
                     {'mac_address': value.decode(), 'required_length': (6, 8, 20)},
                 )
@@ -96,9 +96,9 @@ class MacAddress(str):
                     mac_address[i + 1] = byte_value
                     x += 5
                 except ValueError as e:
-                    raise PydanticCustomError('invalid MAC address', 'Unrecognized format') from e
+                    raise PydanticCustomError('mac_address_format', 'Unrecognized format') from e
 
         else:
-            raise PydanticCustomError('invalid MAC address', 'Unrecognized format')
+            raise PydanticCustomError('mac_address_format', 'Unrecognized format')
 
         return ':'.join(f'{b:02x}' for b in mac_address)

--- a/tests/test_mac_address.py
+++ b/tests/test_mac_address.py
@@ -2,74 +2,108 @@ from typing import Any
 
 import pytest
 from pydantic import BaseModel, ValidationError
-from pydantic_core import PydanticCustomError
 
 from pydantic_extra_types.mac_address import MacAddress
 
 
+class Network(BaseModel):
+    mac_address: MacAddress
+
+
 @pytest.mark.parametrize(
-    'mac_address, valid',
+    'mac_address, result, valid',
     [
         # Valid MAC addresses
-        ('00:00:5e:00:53:01', True),
-        ('02:00:5e:10:00:00:00:01', True),
-        ('00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01', True),
-        ('00-00-5e-00-53-01', True),
-        ('02-00-5e-10-00-00-00-01', True),
-        ('00-00-00-00-fe-80-00-00-00-00-00-00-02-00-5e-10-00-00-00-01', True),
-        ('0000.5e00.5301', True),
-        ('0200.5e10.0000.0001', True),
-        ('0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001', True),
+        ('00:00:5e:00:53:01', '00:00:5e:00:53:01', True),
+        ('02:00:5e:10:00:00:00:01', '02:00:5e:10:00:00:00:01', True),
+        (
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            True,
+        ),
+        ('00-00-5e-00-53-01', '00:00:5e:00:53:01', True),
+        ('02-00-5e-10-00-00-00-01', '02:00:5e:10:00:00:00:01', True),
+        (
+            '00-00-00-00-fe-80-00-00-00-00-00-00-02-00-5e-10-00-00-00-01',
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            True,
+        ),
+        ('0000.5e00.5301', '00:00:5e:00:53:01', True),
+        ('0200.5e10.0000.0001', '02:00:5e:10:00:00:00:01', True),
+        (
+            '0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001',
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            True,
+        ),
         # Invalid MAC addresses
-        ('0200.5e10.0000.001', False),
-        ('00-00-5e-00-53-0', False),
-        ('00:00:5e:00:53:1', False),
-        ('02:00:5e:10:00:00:00:1', False),
-        ('00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:1', False),
-        ('0200.5e10.0000.001', False),  # Invalid length
-        ('00-00-5e-00-53-0', False),  # Missing character
-        ('00:00:5e:00:53:1', False),  # Missing leading zero
-        ('00:00:5g:00:53:01', False),  # Invalid hex digit 'g'
-        ('00-00-5e-00-53-01:', False),  # Extra separator at the end
-        ('00-00-5e-00-53-01-', False),  # Extra separator at the end
-        ('00.00.5e.00.53.01.', False),  # Extra separator at the end
-        ('00:00:5e:00:53:', False),  # Incomplete MAC address
+        ('0200.5e10.0000.001', None, False),
+        ('00-00-5e-00-53-0', None, False),
+        ('00:00:5e:00:53:1', None, False),
+        ('02:00:5e:10:00:00:00:1', None, False),
+        ('00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:1', None, False),
+        ('0200.5e10.0000.001', None, False),  # Invalid length
+        ('00-00-5e-00-53-0', None, False),  # Missing character
+        ('00:00:5e:00:53:1', None, False),  # Missing leading zero
+        ('00:00:5g:00:53:01', None, False),  # Invalid hex digit 'g'
+        ('00.00.5e.0.3.01.0.0.5e.0.53.01', None, False),
+        ('00-00-5e-00-53-01:', None, False),  # Extra separator at the end
+        ('00000.5e000.5301', None, False),
+        ('000.5e0.530001', None, False),
+        ('0000.5e#0./301', None, False),
+        (b'12.!4.5!.7/.#G.AB......', None, False),
+        ('12.!4.5!.7/.#G.AB', None, False),
+        ('00-00-5e-00-53-01-', None, False),  # Extra separator at the end
+        ('00.00.5e.00.53.01.', None, False),  # Extra separator at the end
+        ('00:00:5e:00:53:', None, False),  # Incomplete MAC address
+        (float(12345678910111213), None, False),
     ],
 )
-def test_format_for_mac_address(mac_address: str, valid: bool):
+def test_format_for_mac_address(mac_address: Any, result: str, valid: bool):
     if valid:
-        assert MacAddress(mac_address) == mac_address
+        assert Network(mac_address=MacAddress(mac_address)).mac_address == result
     else:
-        with pytest.raises(PydanticCustomError, match='format'):
-            MacAddress(mac_address)
+        with pytest.raises(ValidationError, match='format'):
+            Network(mac_address=MacAddress(mac_address))
 
 
 @pytest.mark.parametrize(
-    'mac_address, valid',
+    'mac_address, result, valid',
     [
         # Valid MAC addresses
-        ('00:00:5e:00:53:01', True),
-        ('02:00:5e:10:00:00:00:01', True),
-        ('00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01', True),
-        ('00-00-5e-00-53-01', True),
-        ('02-00-5e-10-00-00-00-01', True),
-        ('00-00-00-00-fe-80-00-00-00-00-00-00-02-00-5e-10-00-00-00-01', True),
-        ('0000.5e00.5301', True),
-        ('0200.5e10.0000.0001', True),
-        ('0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001', True),
+        ('00:00:5e:00:53:01', '00:00:5e:00:53:01', True),
+        ('02:00:5e:10:00:00:00:01', '02:00:5e:10:00:00:00:01', True),
+        (
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            True,
+        ),
+        ('00-00-5e-00-53-01', '00:00:5e:00:53:01', True),
+        ('02-00-5e-10-00-00-00-01', '02:00:5e:10:00:00:00:01', True),
+        (
+            '00-00-00-00-fe-80-00-00-00-00-00-00-02-00-5e-10-00-00-00-01',
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            True,
+        ),
+        ('0000.5e00.5301', '00:00:5e:00:53:01', True),
+        ('0200.5e10.0000.0001', '02:00:5e:10:00:00:00:01', True),
+        (
+            '0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001',
+            '00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01',
+            True,
+        ),
         # Invalid MAC addresses
-        ('0', False),
-        ('00:00:00', False),
-        ('00-00-5e-00-53-01-01', False),
-        ('0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001.0000.0001', False),
+        ('0', None, False),
+        ('00:00:00', None, False),
+        ('00-00-5e-00-53-01-01', None, False),
+        ('0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001.0000.0001', None, False),
     ],
 )
-def test_length_for_mac_address(mac_address: str, valid: bool):
+def test_length_for_mac_address(mac_address: str, result: str, valid: bool):
     if valid:
-        assert MacAddress(mac_address) == mac_address
+        assert Network(mac_address=MacAddress(mac_address)).mac_address == result
     else:
-        with pytest.raises(PydanticCustomError, match='Length'):
-            MacAddress(mac_address)
+        with pytest.raises(ValueError, match='Length'):
+            Network(mac_address=MacAddress(mac_address))
 
 
 @pytest.mark.parametrize(
@@ -77,7 +111,6 @@ def test_length_for_mac_address(mac_address: str, valid: bool):
     [
         # Valid MAC addresses
         ('00:00:5e:00:53:01', True),
-        (b'00:00:5e:00:53:01', True),
         (MacAddress('00:00:5e:00:53:01'), True),
         # Invalid MAC addresses
         (0, False),
@@ -86,12 +119,10 @@ def test_length_for_mac_address(mac_address: str, valid: bool):
 )
 def test_type_for_mac_address(mac_address: Any, valid: bool):
     if valid:
-        MacAddress(mac_address)
+        Network(mac_address=MacAddress(mac_address))
     else:
-        with pytest.raises(
-            PydanticCustomError, match='value is not a valid Mac Address: value must be a string or bytes'
-        ):
-            MacAddress(mac_address)
+        with pytest.raises(ValidationError, match='MAC address must be 14'):
+            Network(mac_address=MacAddress(mac_address))
 
 
 def test_model_validation():
@@ -107,7 +138,7 @@ def test_model_validation():
             'ctx': {'mac_address': '1234', 'required_length': 14},
             'input': '1234',
             'loc': ('mac_address',),
-            'msg': 'Length for a 1234 mac address must be 14',
-            'type': 'mac_address_len',
+            'msg': 'Length for a 1234 MAC address must be 14',
+            'type': 'invalid MAC address',
         }
     ]

--- a/tests/test_mac_address.py
+++ b/tests/test_mac_address.py
@@ -139,6 +139,6 @@ def test_model_validation():
             'input': '1234',
             'loc': ('mac_address',),
             'msg': 'Length for a 1234 MAC address must be 14',
-            'type': 'invalid MAC address',
+            'type': 'mac_address_len',
         }
     ]


### PR DESCRIPTION
There's a MAC address validation issue here [PR](https://github.com/pydantic/pydantic-extra-types/pull/71)

This PR deletes the `__init__` function and uses the pydantic functions to return a MAC address in the correct format. 

Selected Reviewer: @Kludex