### PR TITLE
dataclass from pydantic.dataclasses instead of dataclasses

### DIFF
--- a/pydantic_extra_types/coordinate.py
+++ b/pydantic_extra_types/coordinate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 from typing import Any, ClassVar, Mapping, Tuple, Union
 
 from pydantic import GetCoreSchemaHandler


### PR DESCRIPTION
Fixes pydantic/pydantic-extra-types #88 