### PR TITLE
fix validate_digits actually allowing non digit characters

### DIFF
--- a/pydantic_extra_types/payment.py
+++ b/pydantic_extra_types/payment.py
@@ -88,7 +88,7 @@ class PaymentCardNumber(str):
         Raises:
             PydanticCustomError: If the card number is not all digits.
         """
-        if not card_number or not all("0" <= c <= "9" for c in card_number):
+        if not card_number or not all('0' <= c <= '9' for c in card_number):
             raise PydanticCustomError('payment_card_number_digits', 'Card number is not all digits')
 
     @classmethod

--- a/pydantic_extra_types/payment.py
+++ b/pydantic_extra_types/payment.py
@@ -88,7 +88,7 @@ class PaymentCardNumber(str):
         Raises:
             PydanticCustomError: If the card number is not all digits.
         """
-        if not card_number.isdigit():
+        if not card_number or not all("0" <= c <= "9" for c in card_number):
             raise PydanticCustomError('payment_card_number_digits', 'Card number is not all digits')
 
     @classmethod

--- a/tests/test_types_payment.py
+++ b/tests/test_types_payment.py
@@ -39,6 +39,8 @@ def test_validate_digits():
     assert PaymentCardNumber.validate_digits(digits) is None
     with pytest.raises(PydanticCustomError, match='Card number is not all digits'):
         PaymentCardNumber.validate_digits('hello')
+    with pytest.raises(PydanticCustomError, match='Card number is not all digits'):
+        PaymentCardNumber.validate_digits('²')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`str.isdigit` method actually allows non digit characters like `²` or `⑥`.

```python
>>> from pydantic_extra_types.payment import PaymentCardNumber
>>> PaymentCardNumber("²")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rcaillon/.local/lib/python3.10/site-packages/pydantic_extra_types/payment.py", line 47, in __init__
    card_number = self.validate_luhn_check_digit(card_number)
  File "/home/rcaillon/.local/lib/python3.10/site-packages/pydantic_extra_types/payment.py", line 108, in validate_luhn_check_digit
    sum_ = int(card_number[-1])
ValueError: invalid literal for int() with base 10: '²'
>>> PaymentCardNumber("⑥")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rcaillon/.local/lib/python3.10/site-packages/pydantic_extra_types/payment.py", line 47, in __init__
    card_number = self.validate_luhn_check_digit(card_number)
  File "/home/rcaillon/.local/lib/python3.10/site-packages/pydantic_extra_types/payment.py", line 108, in validate_luhn_check_digit
    sum_ = int(card_number[-1])
ValueError: invalid literal for int() with base 10: '⑥'
```