### PR TITLE
Fix refs blocking docs build

### DIFF
--- a/pydantic_extra_types/isbn.py
+++ b/pydantic_extra_types/isbn.py
@@ -16,7 +16,7 @@ def isbn10_digit_calc(isbn: str) -> str:
     Calc a ISBN-10 last digit from the provided str value. More information of validation algorithm on [Wikipedia](https://en.wikipedia.org/wiki/ISBN#Check_digits)
 
     Args:
-        value: The str value representing the ISBN in 10 digits.
+        isbn: The str value representing the ISBN in 10 digits.
 
     Returns:
         The calculated last digit.
@@ -35,7 +35,7 @@ def isbn13_digit_calc(isbn: str) -> str:
     Calc a ISBN-13 last digit from the provided str value. More information of validation algorithm on [Wikipedia](https://en.wikipedia.org/wiki/ISBN#Check_digits)
 
     Args:
-        value: The str value representing the ISBN in 13 digits.
+        isbn: The str value representing the ISBN in 13 digits.
 
     Returns:
         The calculated last digit.


### PR DESCRIPTION
```
WARNING -  griffe: /Users/programming/pydantic_work/pydantic-extra-types/pydantic_extra_types/isbn.py:18: No type or
           annotation for parameter 'value'
WARNING -  griffe: /Users/programming/pydantic_work/pydantic-extra-types/pydantic_extra_types/isbn.py:18: Parameter 'value'
           does not appear in the function signature
WARNING -  griffe: /Users/programming/pydantic_work/pydantic-extra-types/pydantic_extra_types/isbn.py:37: No type or
           annotation for parameter 'value'
WARNING -  griffe: /Users/programming/pydantic_work/pydantic-extra-types/pydantic_extra_types/isbn.py:37: Parameter 'value'
           does not appear in the function signature
```