### PR TITLE
Do not pin the ”major” version of pycountry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dynamic = ['version']
 [project.optional-dependencies]
 all = [
     'phonenumbers>=8,<9',
-    'pycountry>=23,<24',
+    'pycountry>=23',
     'python-ulid>=1,<2; python_version<"3.9"',
     'python-ulid>=1,<3; python_version>="3.9"',
     'pendulum>=3.0.0,<4.0.0'


### PR DESCRIPTION
Since pycountry uses a calendar-based versioning scheme, this doesn’t have the effect it would for a SemVer dependency. Breaking changes are not more likely to happen at the beginning of a calendar year than in the middle of one, and pinning the version is likely to cause more headaches than it prevents.