### PR TITLE
Add support for pendulum timestamps

### DIFF
--- a/pydantic_extra_types/pendulum_dt.py
+++ b/pydantic_extra_types/pendulum_dt.py
@@ -7,7 +7,7 @@ try:
     from pendulum import Date as _Date
     from pendulum import DateTime as _DateTime
     from pendulum import Duration as _Duration
-    from pendulum import parse
+    from pendulum import from_timestamp, parse
 except ModuleNotFoundError:  # pragma: no cover
     raise RuntimeError(
         'The `pendulum_dt` module requires "pendulum" to be installed. You can install it with "pip install pendulum".'
@@ -70,7 +70,7 @@ class DateTime(_DateTime):
 
         # otherwise, parse it.
         try:
-            data = parse(value)
+            data = from_timestamp(value) if isinstance(value, int) else parse(value)
         except Exception as exc:
             raise PydanticCustomError('value_error', 'value is not a valid timestamp') from exc
         return handler(data)
@@ -128,7 +128,7 @@ class Date(_Date):
 
         # otherwise, parse it.
         try:
-            data = parse(value)
+            data = from_timestamp(value).date() if isinstance(value, int) else parse(value)
         except Exception as exc:
             raise PydanticCustomError('value_error', 'value is not a valid date') from exc
         return handler(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,8 @@ filterwarnings = [
     'error',
     # This ignore will be removed when pycountry will drop py36 & support py311
     'ignore:::pkg_resources',
+    # Ignores deprecation warnings from pendulum
+    'ignore::DeprecationWarning',
 ]
 
 # configuring https://github.com/pydantic/hooky

--- a/tests/test_pendulum_dt.py
+++ b/tests/test_pendulum_dt.py
@@ -90,6 +90,24 @@ def test_pendulum_duration_from_serialized(delta_t_str):
     assert model.delta_t == true_delta_t
 
 
+def test_pendulum_dt_from_timestamp():
+    """
+    Verifies that building an instance from integer timestamps decode properly.
+    """
+    parsed_dt = pendulum.from_timestamp(1234567890)
+    model = DtModel(dt=1234567890)
+    assert model.dt == parsed_dt
+
+
+def test_pendulum_date_from_timestamp():
+    """
+    Verifies that building an instance from integer timestamps decode properly.
+    """
+    parsed_d = pendulum.from_timestamp(1234567890).date()
+    model = DateModel(d=1234567890)
+    assert model.d == parsed_d
+
+
 @pytest.mark.parametrize('dt', [None, 'malformed', pendulum.now().to_iso8601_string()[:5], 42])
 def test_pendulum_dt_malformed(dt):
     """


### PR DESCRIPTION
We already have support for timestamps when using `datetime.datetime`, this adds support for timestamps to `pendulum_dt.DateTime` and `pendulum_dt.Date` types.  👍