### PR TITLE
feature: Improve phone number validator

### DIFF
--- a/pydantic_extra_types/phone_numbers.py
+++ b/pydantic_extra_types/phone_numbers.py
@@ -7,7 +7,7 @@ This class depends on the [phonenumbers] package, which is a Python port of Goog
 
 from __future__ import annotations
 
-from typing import Any, Callable, ClassVar, Generator
+from typing import Any, ClassVar
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import PydanticCustomError, core_schema
@@ -19,8 +19,6 @@ except ModuleNotFoundError as e:  # pragma: no cover
         '`PhoneNumber` requires "phonenumbers" to be installed. You can install it with "pip install phonenumbers"'
     ) from e
 
-GeneratorCallableStr = Generator[Callable[..., str], None, None]
-
 
 class PhoneNumber(str):
     """
@@ -28,19 +26,13 @@ class PhoneNumber(str):
     is a Python port of Google's [libphonenumber](https://github.com/google/libphonenumber/).
     """
 
-    supported_regions: list[str] = sorted(phonenumbers.SUPPORTED_REGIONS)
-    """The supported regions."""
-    supported_formats: list[str] = sorted([f for f in phonenumbers.PhoneNumberFormat.__dict__.keys() if f.isupper()])
-    """The supported phone number formats."""
+    supported_regions: list[str] = []
+    """The supported regions. If empty, all regions are supported."""
 
     default_region_code: ClassVar[str | None] = None
     """The default region code to use when parsing phone numbers without an international prefix."""
     phone_format: str = 'RFC3966'
     """The format of the phone number."""
-    min_length: int = 7
-    """The minimum length of the phone number."""
-    max_length: int = 64
-    """The maximum length of the phone number."""
 
     @classmethod
     def __get_pydantic_json_schema__(
@@ -54,7 +46,7 @@ class PhoneNumber(str):
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         return core_schema.with_info_after_validator_function(
             cls._validate,
-            core_schema.str_schema(min_length=cls.min_length, max_length=cls.max_length),
+            core_schema.str_schema(),
         )
 
     @classmethod
@@ -65,6 +57,11 @@ class PhoneNumber(str):
             raise PydanticCustomError('value_error', 'value is not a valid phone number') from exc
         if not phonenumbers.is_valid_number(parsed_number):
             raise PydanticCustomError('value_error', 'value is not a valid phone number')
+
+        if cls.supported_regions and not any(
+            phonenumbers.is_valid_number_for_region(parsed_number, region_code=region) for region in cls.supported_regions
+        ):
+            raise PydanticCustomError('value_error', 'value is not from a supported region')
 
         return phonenumbers.format_number(parsed_number, getattr(phonenumbers.PhoneNumberFormat, cls.phone_format))
 

--- a/pydantic_extra_types/phone_numbers.py
+++ b/pydantic_extra_types/phone_numbers.py
@@ -59,7 +59,8 @@ class PhoneNumber(str):
             raise PydanticCustomError('value_error', 'value is not a valid phone number')
 
         if cls.supported_regions and not any(
-            phonenumbers.is_valid_number_for_region(parsed_number, region_code=region) for region in cls.supported_regions
+            phonenumbers.is_valid_number_for_region(parsed_number, region_code=region)
+            for region in cls.supported_regions
         ):
             raise PydanticCustomError('value_error', 'value is not from a supported region')
 

--- a/tests/test_phone_numbers.py
+++ b/tests/test_phone_numbers.py
@@ -47,6 +47,7 @@ def test_supported_regions() -> None:
     with pytest.raises(ValidationError, match='value is not from a supported region'):
         Something(phone_number='+44 20 7946 0958')
 
+
 def test_parse_error() -> None:
     with pytest.raises(ValidationError, match='value is not a valid phone number'):
         Something(phone_number='555 1212')

--- a/tests/test_phone_numbers.py
+++ b/tests/test_phone_numbers.py
@@ -31,16 +31,21 @@ def test_formats_phone_number() -> None:
 
 
 def test_supported_regions() -> None:
-    assert 'US' in PhoneNumber.supported_regions
-    assert 'GB' in PhoneNumber.supported_regions
+    assert PhoneNumber.supported_regions == []
+    PhoneNumber.supported_regions = ['US']
 
+    assert Something(phone_number='+1 901 555 1212')
 
-def test_supported_formats() -> None:
-    assert 'E164' in PhoneNumber.supported_formats
-    assert 'RFC3966' in PhoneNumber.supported_formats
-    assert '__dict__' not in PhoneNumber.supported_formats
-    assert 'to_string' not in PhoneNumber.supported_formats
+    with pytest.raises(ValidationError, match='value is not from a supported region'):
+        Something(phone_number='+44 20 7946 0958')
 
+    USPhoneNumber = PhoneNumber()
+    USPhoneNumber.supported_regions = ['US']
+    assert USPhoneNumber.supported_regions == ['US']
+    assert Something(phone_number='+1 901 555 1212')
+
+    with pytest.raises(ValidationError, match='value is not from a supported region'):
+        Something(phone_number='+44 20 7946 0958')
 
 def test_parse_error() -> None:
     with pytest.raises(ValidationError, match='value is not a valid phone number'):
@@ -75,8 +80,6 @@ def test_json_schema() -> None:
                 'title': 'Phone Number',
                 'type': 'string',
                 'format': 'phone',
-                'minLength': 7,
-                'maxLength': 64,
             }
         },
         'required': ['phone_number'],


### PR DESCRIPTION
A number of improvements for the existing phone number type validator

Primarily this change adds logic for the existing variable `supported_regions` in the validator, this was currently preforming no function at all. If a user supplies a list of two digit phone number regions to the class the validator will now call `phonenumbers` to check if the parsed number is indeed within one of the regions supplied or else raise a `ValidationError`. If `supported_regions` is an empty list (As is now the default), a valid phone number from any region will be accepted.

Additionally, this change:
- Removes unused imports and unused Generator type definition
- Removes non functional `supported_formats` variable , these values can be looked up from the `phonenumbers` library if needed, no need to re-instantiate this here
- Removes `min_length` and `max_length` parameters, seeing as this is a wrapper around `phonenumbers`, the resultant string length should be the responsibility for formatting operation from that library.