### PR TITLE
✨ deprecate `semver` in favor of `semantic_version`

### DIFF
--- a/pydantic_extra_types/semver.py
+++ b/pydantic_extra_types/semver.py
@@ -12,10 +12,16 @@ if sys.version_info < (3, 9):  # pragma: no cover
 else:
     from typing import Annotated  # pragma: no cover
 
+import warnings
+
 from pydantic import GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 from semver import Version
+
+warnings.warn(
+    'Use from pydantic_extra_types.semver import SemanticVersion instead. Will be removed in 3.0.0.', DeprecationWarning
+)
 
 
 class _VersionPydanticAnnotation(Version):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     'Topic :: Internet',
 ]
 requires-python = '>=3.8'
-dependencies = ['pydantic>=2.5.2']
+dependencies = ['pydantic>=2.5.2','typing-extensions']
 dynamic = ['version']
 
 [project.optional-dependencies]
@@ -123,7 +123,8 @@ filterwarnings = [
     # This ignore will be removed when pycountry will drop py36 & support py311
     'ignore:::pkg_resources',
     # This ignore will be removed when pendulum fixes https://github.com/sdispater/pendulum/issues/834
-    'ignore:datetime.datetime.utcfromtimestamp.*:DeprecationWarning'
+    'ignore:datetime.datetime.utcfromtimestamp.*:DeprecationWarning',
+    ' ignore:Use from pydantic_extra_types.semver import SemanticVersion instead. Will be removed in 3.0.0.:DeprecationWarning'
 ]
 
 # configuring https://github.com/pydantic/hooky

--- a/tests/test_semantic_version.py
+++ b/tests/test_semantic_version.py
@@ -12,12 +12,14 @@ def application_object_fixture():
     return Application
 
 
-def test_valid_semantic_version(SemanticVersionObject):
-    application = SemanticVersionObject(version='1.0.0')
+@pytest.mark.parametrize('version', ['1.0.0', '1.0.0-alpha.1', '1.0.0-alpha.1+build.1', '1.2.3'])
+def test_valid_semantic_version(SemanticVersionObject, version):
+    application = SemanticVersionObject(version=version)
     assert application.version
-    assert application.model_dump() == {'version': '1.0.0'}
+    assert application.model_dump() == {'version': version}
 
 
-def test_invalid_semantic_version(SemanticVersionObject):
+@pytest.mark.parametrize('invalid_version', ['no dots string', 'with.dots.string', ''])
+def test_invalid_semantic_version(SemanticVersionObject, invalid_version):
     with pytest.raises(ValidationError):
-        SemanticVersionObject(version='Peter Maffay')
+        SemanticVersionObject(version=invalid_version)


### PR DESCRIPTION
closes #205  (shedules removal for next magor version so we do not break api contract)

reasons for selecting semantic_version in favor of semver is missing usual 

```python
try:
 <import library that does this>
except:
  raise RuntimeError(<here is how you install it>)
````

TLDR: it requres much more effort

however i folded test  from semver to semantic_version and extrended it so it can be just removed on deprecation