### PR TITLE
Allow python-ulid 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ all = [
     'pycountry>=23',
     'semver>=3.0.2',
     'python-ulid>=1,<2; python_version<"3.9"',
-    'python-ulid>=1,<3; python_version>="3.9"',
+    'python-ulid>=1,<4; python_version>="3.9"',
     'pendulum>=3.0.0,<4.0.0',
     'pytz>=2024.1',
     'semver~=3.0.2',


### PR DESCRIPTION
The API change in this major release is that a `TypeError` is raised instead of a `ValueError` if a constructor is called with the wrong type. I don’t *think* this requires any code changes in `pydantic-extra-types`, but it’s worth double-checking.

https://github.com/mdomke/python-ulid/releases/tag/3.0.0

Tested with:

```
$ python3.12 -m venv _e
$ . _e/bin/activate
(_e) $ pip install -e .[all]
(_e) $ pip install -r requirements/testing.in
(_e) $ python -m pytest
```