### PR TITLE
isolate url in Currency

### DIFF
--- a/pydantic_extra_types/currency_code.py
+++ b/pydantic_extra_types/currency_code.py
@@ -132,7 +132,7 @@ class Currency(str):
             raise PydanticCustomError(
                 'InvalidCurrency',
                 'Invalid currency code.'
-                ' See https://en.wikipedia.org/wiki/ISO_4217. '
+                ' See https://en.wikipedia.org/wiki/ISO_4217 . '
                 'Bonds, testing and precious metals codes are not allowed.',
             )
         return currency_symbol

--- a/tests/test_currency_code.py
+++ b/tests/test_currency_code.py
@@ -56,7 +56,7 @@ def test_forbidden_everyday(forbidden_currency):
         ValidationError,
         match=re.escape(
             '1 validation error for CurrencyCheckingModel\ncurrency\n  '
-            'Invalid currency code. See https://en.wikipedia.org/wiki/ISO_4217. '
+            'Invalid currency code. See https://en.wikipedia.org/wiki/ISO_4217 . '
             'Bonds, testing and precious metals codes are not allowed. '
             f"[type=InvalidCurrency, input_value='{forbidden_currency}', input_type=str]"
         ),


### PR DESCRIPTION
My shell added the dot to the url and brought me to a non existing wikipedia page. Adding a space after the url prevents that from happening