### PR TITLE
lower case currency is valid

### DIFF
--- a/pydantic_extra_types/currency_code.py
+++ b/pydantic_extra_types/currency_code.py
@@ -68,6 +68,7 @@ class ISO4217(str):
         Raises:
             PydanticCustomError: If the ISO 4217 currency code is not valid.
         """
+        currency_code = currency_code.upper()
         if currency_code not in cls.allowed_currencies:
             raise PydanticCustomError(
                 'ISO4217', 'Invalid ISO 4217 currency code. See https://en.wikipedia.org/wiki/ISO_4217'
@@ -128,6 +129,7 @@ class Currency(str):
         Raises:
             PydanticCustomError: If the ISO 4217 currency code is not valid or is bond, precious metal or testing code.
         """
+        currency_symbol = currency_symbol.upper()
         if currency_symbol not in cls.allowed_currencies:
             raise PydanticCustomError(
                 'InvalidCurrency',

--- a/tests/test_currency_code.py
+++ b/tests/test_currency_code.py
@@ -25,6 +25,12 @@ def test_ISO4217_code_ok(currency: str):
     assert model.model_dump() == {'currency': currency}  # test serialization
 
 
+@pytest.mark.parametrize('currency', ['USD', 'usd', 'UsD'])
+def test_ISO4217_code_ok_lower_case(currency: str):
+    model = ISO4217CheckingModel(currency=currency)
+    assert model.currency == currency.upper()
+
+
 @pytest.mark.parametrize(
     'currency',
     filter(
@@ -36,6 +42,12 @@ def test_everyday_code_ok(currency: str):
     model = CurrencyCheckingModel(currency=currency)
     assert model.currency == currency
     assert model.model_dump() == {'currency': currency}  # test serialization
+
+
+@pytest.mark.parametrize('currency', ['USD', 'usd', 'UsD'])
+def test_everyday_code_ok_lower_case(currency: str):
+    model = CurrencyCheckingModel(currency=currency)
+    assert model.currency == currency.upper()
 
 
 def test_ISO4217_fails():


### PR DESCRIPTION
I think "eur" should be accepted as a currency and stored as "EUR" just like basically any date in a string is accepted as (and converted to) a datetime object