### PR TITLE
Added Time parsing to pendulum_dt

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-extra-types"
-version = "2.10.1"
+version = "2.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This PR adds support for the `pendulum.Time` object to the library. Note that this change was obnoxious to implement because pendulum does not parse time values uniformly. As an example, when calling `pendulum.instance` on a `datetime.time` object, no time zone is inserted unless it is explicitly added to the `datetime.time` object. However, if `pendulum.Time.instance` is called with a `datetime.time` object, then the timezone will be inferred to be UTC unless it is provided. Additionally, when parsing a string, timezones are ignored regardless of how the parsing is done.