### PR TITLE
Fix a typo in the DeprecationWarning warning of _VersionPydanticAnnotation

### DIFF
--- a/pydantic_extra_types/semver.py
+++ b/pydantic_extra_types/semver.py
@@ -13,7 +13,8 @@ from semver import Version
 from typing_extensions import Annotated
 
 warnings.warn(
-    'Use from pydantic_extra_types.semantic_version import SemanticVersion instead. Will be removed in 3.0.0.', DeprecationWarning
+    'Use from pydantic_extra_types.semantic_version import SemanticVersion instead. Will be removed in 3.0.0.',
+    DeprecationWarning,
 )
 
 

--- a/pydantic_extra_types/semver.py
+++ b/pydantic_extra_types/semver.py
@@ -13,7 +13,7 @@ from semver import Version
 from typing_extensions import Annotated
 
 warnings.warn(
-    'Use from pydantic_extra_types.semver import SemanticVersion instead. Will be removed in 3.0.0.', DeprecationWarning
+    'Use from pydantic_extra_types.semantic_version import SemanticVersion instead. Will be removed in 3.0.0.', DeprecationWarning
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ filterwarnings = [
     'ignore:::pkg_resources',
     # This ignore will be removed when pendulum fixes https://github.com/sdispater/pendulum/issues/834
     'ignore:datetime.datetime.utcfromtimestamp.*:DeprecationWarning',
-    ' ignore:Use from pydantic_extra_types.semver import SemanticVersion instead. Will be removed in 3.0.0.:DeprecationWarning'
+    ' ignore:Use from pydantic_extra_types.semantic_version import SemanticVersion instead. Will be removed in 3.0.0.:DeprecationWarning'
 ]
 
 # configuring https://github.com/pydantic/hooky


### PR DESCRIPTION
This PR fixes a typo in the deprecation warning message of _VersionPydanticAnnotation.
