### PR TITLE
Fix checkdigit calculation for ISBN10

### DIFF
--- a/pydantic_extra_types/isbn.py
+++ b/pydantic_extra_types/isbn.py
@@ -21,11 +21,8 @@ def isbn10_digit_calc(isbn: str) -> str:
         The calculated last digit of the ISBN-10 value.
     """
     total = sum(int(digit) * (10 - idx) for idx, digit in enumerate(isbn[:9]))
-
-    for check_digit in range(1, 11):
-        if (total + check_digit) % 11 == 0:
-            valid_check_digit = 'X' if check_digit == 10 else str(check_digit)
-
+    diff = (11 - total) % 11
+    valid_check_digit = 'X' if diff == 10 else str(diff)
     return valid_check_digit
 
 

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -122,6 +122,7 @@ isbn_last_digit_test_cases = [
     ('080442957X', '9780804429573', True),  # ISBN-10 ending in "X" as input
     ('9788584390670', '9788584390670', True),  # ISBN-13 Starting with 978
     ('9790306406156', '9790306406156', True),  # ISBN-13 starting with 979
+    ('8306018060', '9788306018066', True),  # ISBN-10 as input
     # Invalid ISBNs
     ('8537809663', None, False),  # ISBN-10 as input with wrong last digit
     ('9788537809661', None, False),  # ISBN-13 as input with wrong last digit


### PR DESCRIPTION
The code calculating checkdigit for ISBN10 runs a loop for numbers between 1 and 10 included. There are two issues:

1. it ignores the possibility of getting the checkdigit of `0` and then raises an `UnboundLocalError` because the variable `valid_check_digit` is never set
2. it actually does not have to run a loop to calculate this variable, therefore a minor performance optimization is possible

This PR includes an added test with a valid ISBN10 ending with a `0` that failed earlier but passes now.