### PR TITLE
Make checksum calculation more descriptive

### DIFF
--- a/pydantic_extra_types/isbn.py
+++ b/pydantic_extra_types/isbn.py
@@ -5,6 +5,7 @@ ISBN (International Standard Book Number) is a numeric commercial book identifie
 
 from __future__ import annotations
 
+import itertools as it
 from typing import Any
 
 from pydantic import GetCoreSchemaHandler
@@ -38,9 +39,9 @@ def isbn13_digit_calc(isbn: str) -> str:
     Returns:
         The calculated last digit of the ISBN-13 value.
     """
-    total = sum(int(digit) * (1 if idx % 2 == 0 else 3) for idx, digit in enumerate(isbn[:12]))
+    total = sum(int(digit) * factor for digit, factor in zip(isbn[:12], it.cycle((1, 3))))
 
-    check_digit = (10 - (total % 10)) % 10
+    check_digit = (10 - total) % 10
 
     return str(check_digit)
 

--- a/pydantic_extra_types/routing_number.py
+++ b/pydantic_extra_types/routing_number.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import itertools as it
 from typing import Any, ClassVar
 
 from pydantic import GetCoreSchemaHandler
@@ -83,11 +84,7 @@ class ABARoutingNumber(str):
         Raises:
             PydanticCustomError: If the routing number is incorrect.
         """
-        checksum = (
-            3 * (sum(map(int, [routing_number[0], routing_number[3], routing_number[6]])))
-            + 7 * (sum(map(int, [routing_number[1], routing_number[4], routing_number[7]])))
-            + sum(map(int, [routing_number[2], routing_number[5], routing_number[8]]))
-        )
-        if checksum % 10 != 0:
+        checksum = sum(int(digit) * factor for digit, factor in zip(routing_number, it.cycle((3, 7, 1))))
+        if checksum % 10:
             raise PydanticCustomError('aba_routing_number', 'Incorrect ABA routing transit number')
         return routing_number


### PR DESCRIPTION
This PR just improved the readability of cyclic checksum calculations using `itertools.cycle` for repetitive factors.