### PR TITLE
limit iso8601 serialization of duration to json

### DIFF
--- a/pydantic_extra_types/pendulum_dt.py
+++ b/pydantic_extra_types/pendulum_dt.py
@@ -190,7 +190,7 @@ class Duration(_Duration):
             cls._validate,
             core_schema.timedelta_schema(),
             serialization=core_schema.plain_serializer_function_ser_schema(
-                lambda instance: instance.to_iso8601_string()
+                lambda instance: instance.to_iso8601_string(), when_used='json-unless-none'
             ),
         )
 

--- a/tests/test_pendulum_dt.py
+++ b/tests/test_pendulum_dt.py
@@ -286,26 +286,29 @@ def test_pendulum_duration_from_serialized(delta_t_str):
 @pytest.mark.parametrize(
     'duration',
     [
-        (Duration(months=1)),
-        (Duration(weeks=1)),
-        (Duration(milliseconds=1)),
-        (Duration(microseconds=1)),
-        (Duration(days=1)),
-        (Duration(hours=1)),
-        (Duration(minutes=1)),
-        (Duration(seconds=1)),
-        (Duration(months=2, days=5)),
-        (Duration(weeks=3, hours=12)),
-        (Duration(days=10, minutes=30)),
-        (Duration(weeks=1, days=2, hours=3)),
-        (Duration(seconds=30, milliseconds=500)),
+        Duration(months=1),
+        Duration(weeks=1),
+        Duration(milliseconds=1),
+        Duration(microseconds=1),
+        Duration(days=1),
+        Duration(hours=1),
+        Duration(minutes=1),
+        Duration(seconds=1),
+        Duration(months=2, days=5),
+        Duration(weeks=3, hours=12),
+        Duration(days=10, minutes=30),
+        Duration(weeks=1, days=2, hours=3),
+        Duration(seconds=30, milliseconds=500),
     ],
 )
 def test_pendulum_duration_serialization_roundtrip(duration):
     adapter = TypeAdapter(Duration)
-    serialized = adapter.dump_python(duration)
-    deserialized = TypeAdapter.validate_python(adapter, serialized)
-    assert deserialized == duration
+    python_serialized = adapter.dump_python(duration)
+    json_serialized = adapter.dump_json(duration)
+    deserialized = TypeAdapter.validate_json(adapter, json_serialized)
+    assert deserialized == python_serialized == duration
+    assert deserialized.years == python_serialized.years == duration.years
+    assert deserialized.months == python_serialized.months == duration.months
 
 
 def get_invalid_dt_common():


### PR DESCRIPTION
Follow up to #296 which fixes/improves (de-)serialization of `Duration` models.

This PR:
- limits iso8601 serialization to json
- adds json serialization to test case
- checks for equality of years and months explicitly