### PR TITLE
Default to using system zoneinfo if available

### DIFF
--- a/pydantic_extra_types/timezone_name.py
+++ b/pydantic_extra_types/timezone_name.py
@@ -44,8 +44,11 @@ def _warn_about_pytz_usage() -> None:
 
 def get_timezones() -> set[str]:
     """Determine the timezone provider and return available timezones."""
-    if _is_available('zoneinfo') and _is_available('tzdata'):  # pragma: no cover
-        return _tz_provider_from_zone_info()
+    if _is_available('zoneinfo'):  # pragma: no cover
+        timezones = _tz_provider_from_zone_info()
+        if len(timezones) == 0:  # pragma: no cover
+            raise ImportError('No timezone provider found. Please install tzdata with "pip install tzdata"')
+        return timezones
     elif _is_available('pytz'):  # pragma: no cover
         return _tz_provider_from_pytz()
     else:  # pragma: no cover


### PR DESCRIPTION
The zoneinfo module by default uses the systems timezone information and if not found falls back to tzdata. This change makes `get_timezone()` behave the same allowing for tzdata to fully become an optional dependency for Linux distributions which already include time zone data.

Closes: #291