### PR TITLE
fix: disallow bool as input value for ULID

### DIFF
--- a/pydantic_extra_types/ulid.py
+++ b/pydantic_extra_types/ulid.py
@@ -47,6 +47,8 @@ class ULID(_repr.Representation):
     @classmethod
     def _validate_ulid(cls, value: Any, handler: core_schema.ValidatorFunctionWrapHandler) -> Any:
         ulid: _ULID
+        if isinstance(value, bool):
+            raise PydanticCustomError('ulid_format', 'Unrecognized format')
         try:
             if isinstance(value, int):
                 ulid = _ULID.from_int(value)

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -37,6 +37,9 @@ class Something(BaseModel):
         (109667145845879622871206540411193812282, '2JG4FVY7N8XS4GFVHPXGJZ8S9T', True),
         (109667145845879622871206540411193812283, '2JG4FVY7N8XS4GFVHPXGJZ8S9V', True),
         (109667145845879622871206540411193812284, '2JG4FVY7N8XS4GFVHPXGJZ8S9W', True),
+        # Invalid ULID for bool format
+        (True, None, False),
+        (False, None, False),
     ],
 )
 def test_format_for_ulid(ulid: Any, result: Any, valid: bool):


### PR DESCRIPTION
Since True/False in python pass isinstance(value,int) with I would be reasonable according to principle of least astonishment to additionaly check and discriminate against bool values in ULID validator.