### PR TITLE
🐛 set `@classmethod` in `phone_numbers` schema

### DIFF
--- a/pydantic_extra_types/phone_numbers.py
+++ b/pydantic_extra_types/phone_numbers.py
@@ -172,8 +172,9 @@ class PhoneNumberValidator:
             core_schema.str_schema(),
         )
 
+    @classmethod
     def __get_pydantic_json_schema__(
-        self, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        cls, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> dict[str, Any]:
         json_schema = handler(schema)
         json_schema.update({'format': 'phone'})


### PR DESCRIPTION
I've noticed that this method is not up to convention, as it should be decorated with `@classmethod`.