### PR TITLE
feat(encrypted): add field-level cipher string transformer

### DIFF
--- a/pydantic_extra_types/encrypted.py
+++ b/pydantic_extra_types/encrypted.py
@@ -1,0 +1,94 @@
+"""The `pydantic_extra_types.encrypted` module provides tools for field-level string transformation.
+
+This can be used to implement automatic encryption/decryption patterns with user-provided callables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Literal
+
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic_core import PydanticCustomError, core_schema
+
+
+@dataclass(frozen=True)
+class CipherString:
+    """Apply a string transform function either before or after validation.
+
+    `mode='after'` is useful for request-time encryption (validate plaintext, then encrypt).
+    `mode='before'` is useful for response-time decryption (decrypt first, then validate).
+
+    ```py
+    from typing import Annotated
+
+    from pydantic import BaseModel
+
+    from pydantic_extra_types.encrypted import CipherString
+
+
+    def encrypt(value: str) -> str:
+        return f'enc::{value}'
+
+
+    def decrypt(value: str) -> str:
+        return value.removeprefix('enc::')
+
+
+    class RequestModel(BaseModel):
+        sensitive: Annotated[str, CipherString(encrypt)]
+
+
+    class ResponseModel(BaseModel):
+        sensitive: Annotated[str, CipherString(decrypt, mode='before')]
+    ```
+    """
+
+    transform: Callable[[str], str]
+    """Function used to transform string values."""
+
+    mode: Literal['before', 'after'] = 'after'
+    """Apply transform before validation (`before`) or after validation (`after`)."""
+
+    def __post_init__(self) -> None:
+        if not callable(self.transform):
+            raise ValueError('`transform` must be callable')
+        if self.mode not in {'before', 'after'}:
+            raise ValueError('`mode` must be either "before" or "after"')
+
+    def _apply(self, value: Any, _: core_schema.ValidationInfo) -> Any:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise PydanticCustomError('cipher_string_type', 'Input should be a valid string')
+
+        try:
+            transformed = self.transform(value)
+        except Exception as exc:  # pragma: no cover
+            raise PydanticCustomError('cipher_string_transform', 'Failed to transform value') from exc
+
+        if not isinstance(transformed, str):
+            raise PydanticCustomError('cipher_string_result_type', 'Transform function must return a string')
+        return transformed
+
+    def __get_pydantic_core_schema__(self, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        schema = handler(source)
+        if self.mode == 'before':
+            return core_schema.with_info_before_validator_function(self._apply, schema)
+        return core_schema.with_info_after_validator_function(self._apply, schema)
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> dict[str, Any]:
+        return handler(schema)
+
+    @classmethod
+    def encrypt(cls, transform: Callable[[str], str]) -> CipherString:
+        """Create an encryption-style transformer that runs after validation."""
+        return cls(transform=transform, mode='after')
+
+    @classmethod
+    def decrypt(cls, transform: Callable[[str], str]) -> CipherString:
+        """Create a decryption-style transformer that runs before validation."""
+        return cls(transform=transform, mode='before')

--- a/tests/test_encrypted.py
+++ b/tests/test_encrypted.py
@@ -1,0 +1,99 @@
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from pydantic_extra_types.encrypted import CipherString
+
+
+def encrypt(value: str) -> str:
+    return f'enc::{value}'
+
+
+def decrypt(value: str) -> str:
+    if not value.startswith('enc::'):
+        raise ValueError('invalid encrypted value')
+    return value[5:]
+
+
+class EncryptRequestModel(BaseModel):
+    value: Annotated[str, CipherString.encrypt(encrypt)]
+
+
+class DecryptResponseModel(BaseModel):
+    value: Annotated[str, CipherString.decrypt(decrypt)]
+
+
+class ConstrainedDecryptModel(BaseModel):
+    value: Annotated[str, Field(min_length=3), CipherString.decrypt(decrypt)]
+
+
+class OptionalEncryptModel(BaseModel):
+    value: Annotated[str | None, CipherString.encrypt(encrypt)]
+
+
+def test_encrypt_after_validation() -> None:
+    result = EncryptRequestModel(value='abc')
+    assert result.value == 'enc::abc'
+
+
+def test_decrypt_before_validation() -> None:
+    result = DecryptResponseModel(value='enc::abc')
+    assert result.value == 'abc'
+
+
+def test_before_mode_runs_prior_to_constraints() -> None:
+    with pytest.raises(ValidationError, match='at least 3 characters'):
+        ConstrainedDecryptModel(value='enc::ab')
+
+
+def test_optional_value_none_is_untouched() -> None:
+    assert OptionalEncryptModel(value=None).value is None
+
+
+def test_invalid_mode() -> None:
+    with pytest.raises(ValueError, match='`mode` must be either "before" or "after"'):
+        CipherString(transform=encrypt, mode='invalid')  # type: ignore[arg-type]
+
+
+def test_non_callable_transform() -> None:
+    with pytest.raises(ValueError, match='`transform` must be callable'):
+        CipherString(transform='not-callable')  # type: ignore[arg-type]
+
+
+def test_transform_exception_bubbles_as_validation_error() -> None:
+    with pytest.raises(ValidationError, match='Failed to transform value'):
+        DecryptResponseModel(value='plain-value')
+
+
+def test_transform_must_return_string() -> None:
+    def bad_transform(value: str) -> str:
+        return 1  # type: ignore[return-value]
+
+    class BadModel(BaseModel):
+        value: Annotated[str, CipherString.encrypt(bad_transform)]
+
+    with pytest.raises(ValidationError, match='Transform function must return a string'):
+        BadModel(value='abc')
+
+
+def test_non_string_input() -> None:
+    with pytest.raises(ValidationError, match='Input should be a valid string'):
+        DecryptResponseModel(value=123)  # type: ignore[arg-type]
+
+
+def test_json_schema_remains_string() -> None:
+    assert EncryptRequestModel.model_json_schema() == {
+        'properties': {'value': {'title': 'Value', 'type': 'string'}},
+        'required': ['value'],
+        'title': 'EncryptRequestModel',
+        'type': 'object',
+    }
+
+
+def test_classmethod_constructors() -> None:
+    encrypt_transformer = CipherString.encrypt(encrypt)
+    decrypt_transformer = CipherString.decrypt(decrypt)
+
+    assert encrypt_transformer.mode == 'after'
+    assert decrypt_transformer.mode == 'before'

--- a/tests/test_encrypted.py
+++ b/tests/test_encrypted.py
@@ -1,4 +1,6 @@
-from typing import Annotated
+from __future__ import annotations
+
+from typing import Annotated, Optional
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
@@ -29,7 +31,7 @@ class ConstrainedDecryptModel(BaseModel):
 
 
 class OptionalEncryptModel(BaseModel):
-    value: Annotated[str | None, CipherString.encrypt(encrypt)]
+    value: Annotated[Optional[str], CipherString.encrypt(encrypt)]
 
 
 def test_encrypt_after_validation() -> None:


### PR DESCRIPTION
### Description:

I saw that the issue #129 asks for a reusable way to avoid repeating custom field validators for encrypt/decrypt flows. Right now, there is no dedicated extra type for that pattern. This PR addresses it by adding CipherString, an annotation-based transformer that supports both mode='after' (encrypt after validation) and mode='before' (decrypt before validation), plus convenience constructors and strict error handling.

I also added focused tests that cover encryption, decryption, constraint interaction, optional values, schema output, and error cases.

I used GitHub Copilot GPT-5.3 Codex to help draft the implementation, and then manually reviewed and validated all code and test results.

Closes #129

### Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added a relevant test case for this fix.
- [x] I have run the linting and formatting scripts (make lint).

The screenshot of the full test suite run, for validation (ran on WSL):

<img width="1695" height="976" alt="image" src="https://github.com/user-attachments/assets/59a618e2-5da2-4c4f-9330-e47e617dc1a1" />

The 'import check' test run, validation screenshot:

<img width="1689" height="127" alt="image" src="https://github.com/user-attachments/assets/f2a230d5-1bf5-4748-bfb3-1660c7e87d35" />
