### PR TITLE
feat(pandas): add Timestamp, Series and DataFrame types (#64)

### DIFF
--- a/pydantic_extra_types/pandas_types.py
+++ b/pydantic_extra_types/pandas_types.py
@@ -1,0 +1,137 @@
+"""Pydantic-compatible wrappers for pandas types.
+
+This module provides a Pydantic ``CoreSchema`` for ``pandas.Timestamp`` so it can be used directly
+as a field annotation on a ``BaseModel``. It also exposes lightweight ``Series`` and ``DataFrame``
+annotations that pass instances through unchanged (no schema enforcement) and serialize to
+JSON-friendly Python objects.
+
+pandas is an optional dependency. Install with ``pip install 'pydantic-extra-types[pandas]'``.
+"""
+
+from __future__ import annotations
+
+try:
+    import pandas as pd
+except ModuleNotFoundError as e:  # pragma: no cover
+    raise RuntimeError(
+        'The `pandas_types` module requires "pandas" to be installed. '
+        'You can install it with "pip install pandas" or "pip install pydantic-extra-types[pandas]".'
+    ) from e
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema, PydanticCustomError, core_schema
+
+
+class Timestamp(pd.Timestamp):
+    """A `pandas.Timestamp` annotation usable directly on a Pydantic model.
+
+    ```python
+    from pydantic import BaseModel
+    from pydantic_extra_types.pandas_types import Timestamp
+
+
+    class Event(BaseModel):
+        ts: Timestamp
+
+
+    event = Event(ts='2024-01-01T00:00:00')
+    # > event.ts -> Timestamp('2024-01-01 00:00:00')
+    ```
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> CoreSchema:
+        return core_schema.no_info_plain_validator_function(
+            cls._validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda instance: instance.isoformat(),
+                when_used='json-unless-none',
+            ),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        return {'type': 'string', 'format': 'date-time'}
+
+    @classmethod
+    def _validate(cls, value: Any) -> pd.Timestamp:
+        # Pass through existing pandas / datetime instances.
+        if isinstance(value, pd.Timestamp):
+            return value
+        if isinstance(value, datetime):
+            return pd.Timestamp(value)
+        if isinstance(value, (str, int, float)):
+            try:
+                return pd.Timestamp(value)
+            except (ValueError, TypeError) as exc:
+                raise PydanticCustomError('value_error', 'value is not a valid pandas Timestamp') from exc
+        raise PydanticCustomError('value_error', 'value is not a valid pandas Timestamp')
+
+
+class Series:
+    """Annotation for a `pandas.Series`.
+
+    The Series instance is passed through unchanged (no element-level validation since pandas
+    does not carry that schema information). For JSON serialization the Series is converted via
+    ``Series.to_list()``.
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> CoreSchema:
+        return core_schema.no_info_plain_validator_function(
+            cls._validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda instance: instance.to_list(),
+                when_used='json-unless-none',
+            ),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        return {'type': 'array', 'items': {}}
+
+    @classmethod
+    def _validate(cls, value: Any) -> pd.Series:
+        if isinstance(value, pd.Series):
+            return value
+        if isinstance(value, (list, tuple)):
+            return pd.Series(list(value))
+        raise PydanticCustomError('value_error', 'value is not a valid pandas Series')
+
+
+class DataFrame:
+    """Annotation for a `pandas.DataFrame`.
+
+    The DataFrame instance is passed through unchanged. For JSON serialization the DataFrame is
+    converted via ``DataFrame.to_dict(orient='records')``.
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> CoreSchema:
+        return core_schema.no_info_plain_validator_function(
+            cls._validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda instance: instance.to_dict(orient='records'),
+                when_used='json-unless-none',
+            ),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        return {'type': 'array', 'items': {'type': 'object'}}
+
+    @classmethod
+    def _validate(cls, value: Any) -> pd.DataFrame:
+        if isinstance(value, pd.DataFrame):
+            return value
+        # Accept list of dicts or a dict-of-lists (common pandas constructors).
+        if isinstance(value, (list, dict)):
+            try:
+                return pd.DataFrame(value)
+            except (ValueError, TypeError) as exc:
+                raise PydanticCustomError('value_error', 'value is not a valid pandas DataFrame') from exc
+        raise PydanticCustomError('value_error', 'value is not a valid pandas DataFrame')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,10 @@ all = [
     'tzdata>=2024.1',
     "cron-converter>=1.2.2",
     'uuid-utils>=0.6.0; python_version<"3.14"',
+    'pandas>=2',
 ]
 phonenumbers = ['phonenumbers>=8,<10']
+pandas = ['pandas>=2']
 pycountry = ['pycountry>=23']
 jsonschema = ['jsonschema>=4.0.0']
 semver = ['semver>=3.0.2']

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+pd = pytest.importorskip('pandas')
+
+from pydantic import BaseModel, ValidationError  # noqa: E402
+
+from pydantic_extra_types.pandas_types import DataFrame, Series, Timestamp  # noqa: E402
+
+
+class _TimestampModel(BaseModel):
+    ts: Timestamp
+
+
+class _SeriesModel(BaseModel):
+    model_config = {'arbitrary_types_allowed': True}
+    s: Series
+
+
+class _DataFrameModel(BaseModel):
+    model_config = {'arbitrary_types_allowed': True}
+    df: DataFrame
+
+
+def test_timestamp_from_iso_string() -> None:
+    m = _TimestampModel(ts='2024-01-02T03:04:05')
+    assert isinstance(m.ts, pd.Timestamp)
+    assert m.ts == pd.Timestamp('2024-01-02T03:04:05')
+
+
+def test_timestamp_from_existing_pandas_timestamp() -> None:
+    ts = pd.Timestamp('2024-06-15')
+    m = _TimestampModel(ts=ts)
+    assert m.ts == ts
+
+
+def test_timestamp_from_datetime() -> None:
+    native = dt.datetime(2024, 1, 1, 12, 30)
+    m = _TimestampModel(ts=native)
+    assert m.ts == pd.Timestamp(native)
+
+
+def test_timestamp_from_unix_seconds() -> None:
+    # pandas treats ints as nanoseconds since epoch by default.
+    m = _TimestampModel(ts=0)
+    assert m.ts == pd.Timestamp(0)
+
+
+def test_timestamp_invalid_string_raises() -> None:
+    with pytest.raises(ValidationError):
+        _TimestampModel(ts='not-a-real-date')
+
+
+def test_timestamp_invalid_type_raises() -> None:
+    with pytest.raises(ValidationError):
+        _TimestampModel(ts=object())
+
+
+def test_timestamp_json_serialization() -> None:
+    m = _TimestampModel(ts='2024-01-02T03:04:05')
+    dumped = m.model_dump(mode='json')
+    assert dumped['ts'] == '2024-01-02T03:04:05'
+
+
+def test_timestamp_json_schema() -> None:
+    schema = _TimestampModel.model_json_schema()
+    prop = schema['properties']['ts']
+    assert prop['type'] == 'string'
+    assert prop['format'] == 'date-time'
+
+
+def test_series_passthrough() -> None:
+    s = pd.Series([1, 2, 3])
+    m = _SeriesModel(s=s)
+    assert m.s.equals(s)
+
+
+def test_series_from_list() -> None:
+    m = _SeriesModel(s=[1, 2, 3])
+    assert isinstance(m.s, pd.Series)
+    assert m.s.tolist() == [1, 2, 3]
+
+
+def test_series_invalid_type() -> None:
+    with pytest.raises(ValidationError):
+        _SeriesModel(s=12345)
+
+
+def test_series_json_serialization() -> None:
+    m = _SeriesModel(s=pd.Series([1, 2, 3]))
+    assert m.model_dump(mode='json')['s'] == [1, 2, 3]
+
+
+def test_series_json_schema() -> None:
+    schema = _SeriesModel.model_json_schema()
+    assert schema['properties']['s']['type'] == 'array'
+
+
+def test_dataframe_passthrough() -> None:
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    m = _DataFrameModel(df=df)
+    assert m.df.equals(df)
+
+
+def test_dataframe_from_records() -> None:
+    records = [{'a': 1, 'b': 3}, {'a': 2, 'b': 4}]
+    m = _DataFrameModel(df=records)
+    assert isinstance(m.df, pd.DataFrame)
+    assert m.df.to_dict(orient='records') == records
+
+
+def test_dataframe_invalid_type() -> None:
+    with pytest.raises(ValidationError):
+        _DataFrameModel(df=42)
+
+
+def test_dataframe_json_serialization() -> None:
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    m = _DataFrameModel(df=df)
+    dumped = m.model_dump(mode='json')
+    assert dumped['df'] == [{'a': 1, 'b': 3}, {'a': 2, 'b': 4}]
+
+
+def test_dataframe_json_schema() -> None:
+    schema = _DataFrameModel.model_json_schema()
+    assert schema['properties']['df']['type'] == 'array'
+    assert schema['properties']['df']['items']['type'] == 'object'


### PR DESCRIPTION
## Summary
Closes #64. Adds opt-in pandas type integration. pandas is an optional dependency; importing the new module without it raises a friendly `RuntimeError`.

## Types added (`pydantic_extra_types/pandas_types.py`)
- `Timestamp` — `pd.Timestamp` subclass with Pydantic CoreSchema. Accepts strings, ints/floats, `datetime`, and existing `pd.Timestamp`. JSON serializes to ISO-8601, JSON schema = `{type:string, format:date-time}`.
- `Series` — passthrough validator (also accepts list/tuple). JSON serializes via `to_list()`, schema = `{type:array}`.
- `DataFrame` — passthrough validator (also accepts list/dict). JSON serializes via `to_dict(orient='records')`, schema = array-of-objects.

## Dependency handling
pandas is OPTIONAL via `project.optional-dependencies.pandas = ['pandas>=2']` and added to the `all` extra. Core package deps unchanged.

## Files changed
- `pydantic_extra_types/pandas_types.py` (new, 137 LOC)
- `tests/test_pandas.py` (new, 18 tests)
- `pyproject.toml` — added 2 lines for the pandas extra

## Test plan
- `ruff format` + `ruff check` clean
- All 18 pandas tests pass
- Existing `test_epoch.py` still passes (no regressions)
