### PR TITLE
fix: remove duplicate 'IST' entry in _COMMON_TZ_ABBREVIATIONS

### DIFF
--- a/pydantic_extra_types/timezone_name.py
+++ b/pydantic_extra_types/timezone_name.py
@@ -81,6 +81,8 @@ _COMMON_TZ_ABBREVIATIONS: set[str] = {
     'EEST',
     'WET',
     'WEST',
+    # 'IST' is ambiguous (Irish / Israel / India Standard Time);
+    # a single entry covers membership checks for all three.
     'IST',
     # Asia-Pacific timezones
     'KST',
@@ -92,7 +94,6 @@ _COMMON_TZ_ABBREVIATIONS: set[str] = {
     'AWST',
     'NZST',
     'NZDT',
-    'IST',
     'PKT',
     'WIB',
     'WITA',


### PR DESCRIPTION
## Summary

`_COMMON_TZ_ABBREVIATIONS` in `pydantic_extra_types/timezone_name.py` is a `set[str]` that lists `'IST'` twice — once under the "European timezones" group (line 84, Irish Standard Time) and once under "Asia-Pacific timezones" (line 95, Indian Standard Time). Because the container is a `set`, the second entry is silently deduplicated.

Ruff flags this as [B033](https://docs.astral.sh/ruff/rules/duplicate-value/):

```
pydantic_extra_types/timezone_name.py:95:5: B033 [*] Sets should not contain duplicate item `'IST'`
```

## Fix

Collapse to a single `'IST'` entry with a comment noting that the abbreviation is ambiguous (Irish / Israel / India Standard Time) and one entry covers membership lookup for all three. No behavior change — `'IST' in _COMMON_TZ_ABBREVIATIONS` already returned `True` because of `set` semantics.

## Verification

```
$ ruff check pydantic_extra_types/timezone_name.py --select=B033
All checks passed!
```

Diff is 2 added / 1 removed lines (the explanatory comment + the de-duplicated entry).