### PR TITLE
Don't parameterize tests using non-Collection iterables

### DIFF
--- a/tests/test_currency_code.py
+++ b/tests/test_currency_code.py
@@ -18,7 +18,7 @@ class CurrencyCheckingModel(BaseModel):
 forbidden_currencies = sorted(currency_code._CODES_FOR_BONDS_METAL_TESTING)
 
 
-@pytest.mark.parametrize('currency', map(lambda code: code.alpha_3, pycountry.currencies))
+@pytest.mark.parametrize('currency', [code.alpha_3 for code in pycountry.currencies])
 def test_ISO4217_code_ok(currency: str):
     model = ISO4217CheckingModel(currency=currency)
     assert model.currency == currency
@@ -33,10 +33,7 @@ def test_ISO4217_code_ok_lower_case(currency: str):
 
 @pytest.mark.parametrize(
     'currency',
-    filter(
-        lambda code: code not in currency_code._CODES_FOR_BONDS_METAL_TESTING,
-        map(lambda code: code.alpha_3, pycountry.currencies),
-    ),
+    [code.alpha_3 for code in pycountry.currencies if code.alpha_3 not in currency_code._CODES_FOR_BONDS_METAL_TESTING],
 )
 def test_everyday_code_ok(currency: str):
     model = CurrencyCheckingModel(currency=currency)

--- a/tests/test_language_codes.py
+++ b/tests/test_language_codes.py
@@ -70,14 +70,14 @@ def test_invalid_name(name: str, MovieName):
         MovieName(audio_lang=name)
 
 
-@pytest.mark.parametrize('lang', map(lambda lang: lang.alpha_3, pycountry.languages))
+@pytest.mark.parametrize('lang', [lang.alpha_3 for lang in pycountry.languages])
 def test_iso_ISO639_3_code_ok(lang: str):
     model = ISO3CheckingModel(lang=lang)
     assert model.lang == lang
     assert model.model_dump() == {'lang': lang}  # test serialization
 
 
-@pytest.mark.parametrize('lang', map(lambda lang: lang.alpha_3, pycountry.language_families))
+@pytest.mark.parametrize('lang', [lang.alpha_3 for lang in pycountry.language_families])
 def test_iso_639_5_code_ok(lang: str):
     model = ISO5CheckingModel(lang=lang)
     assert model.lang == lang

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -11,7 +11,7 @@ class ScriptCheck(BaseModel):
     script: ISO_15924
 
 
-@pytest.mark.parametrize('script', map(lambda lang: lang.alpha_4, pycountry.scripts))
+@pytest.mark.parametrize('script', [lang.alpha_4 for lang in pycountry.scripts])
 def test_ISO_15924_code_ok(script: str):
     model = ScriptCheck(script=script)
     assert model.script == script


### PR DESCRIPTION
This is deprecated as of pytest 9.1; see
https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method.