### PR TITLE
test: assert specific IBAN validation errors and cover the check-digit helper

### DIFF
--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from pydantic_extra_types.iban import IBAN
+from pydantic_extra_types.iban import IBAN, _validate_iban_check_digits
 
 
 class BankAccount(BaseModel):
@@ -55,3 +55,52 @@ def test_valid_iban(iban: str) -> None:
 def test_invalid_iban(iban: str) -> None:
     with pytest.raises(ValidationError):
         BankAccount(iban=iban)
+
+
+@pytest.mark.parametrize(
+    ('iban', 'error_type'),
+    [
+        ('GB12', 'iban_invalid_length'),  # shorter than the 5-char minimum
+        ('12345678901234', 'iban_invalid_country_code'),  # country code not letters
+        ('XX29NWBK60161331926819', 'iban_invalid_country_code'),  # unknown country code
+        ('GB29NWBK6016133192681', 'iban_invalid_length'),  # wrong length for GB
+        ('GB29NWBK6016133192681!', 'iban_invalid_characters'),  # non-alphanumeric body
+        ('GBABNWBK60161331926819', 'iban_invalid_check_digits'),  # check digits not numeric
+        ('GB00NWBK60161331926819', 'iban_invalid_checksum'),  # MOD-97 checksum fails
+    ],
+)
+def test_invalid_iban_raises_specific_error(iban: str, error_type: str) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        BankAccount(iban=iban)
+    assert exc_info.value.errors()[0]['type'] == error_type
+
+
+@pytest.mark.parametrize(
+    'iban',
+    [
+        'GB29NWBK60161331926819',
+        'DE89370400440532013000',
+        'FR7630006000011234567890189',
+        'ES9121000418450200051332',
+    ],
+)
+def test_validate_iban_check_digits_accepts_valid(iban: str) -> None:
+    assert _validate_iban_check_digits(iban) is True
+
+
+@pytest.mark.parametrize(
+    'iban',
+    [
+        'GB00NWBK60161331926819',
+        'DE00370400440532013000',
+        'FR0030006000011234567890189',
+    ],
+)
+def test_validate_iban_check_digits_rejects_invalid(iban: str) -> None:
+    assert _validate_iban_check_digits(iban) is False
+
+
+def test_iban_normalizes_spaces_and_case() -> None:
+    account = BankAccount(iban='gb29 nwbk 6016 1331 9268 19')
+    assert account.iban == 'GB29NWBK60161331926819'
+    assert isinstance(account.iban, str)


### PR DESCRIPTION
## Change Summary

The `IBAN` validator raises seven distinct `PydanticCustomError`s (too short, non-letter country code, unknown country code, wrong length, non-alphanumeric body, non-numeric check digits, failed MOD-97 checksum), but `tests/test_iban.py` only asserts that *some* `ValidationError` is raised for invalid input. That means a branch raising the wrong error code — or a branch that never fires because an earlier check shadows it — would pass unnoticed.

This adds:
- **Per-branch error-type assertions**: a parametrized test pinning each invalid input to its exact `error['type']` (`iban_invalid_length`, `iban_invalid_country_code`, `iban_invalid_characters`, `iban_invalid_check_digits`, `iban_invalid_checksum`).
- **Direct tests for `_validate_iban_check_digits`**: the MOD-97 (ISO 7064) helper, with valid and invalid IBANs from several countries.
- A normalization check (spaces stripped, upper-cased).

Tests only — no library code changed. `tests/test_iban.py` passes (`38 passed`) and `ruff check` / `ruff format --check` are clean.

## Related issues

None — improves existing test coverage.