### PR TITLE
fix: reject non-ASCII ABA routing digits

### DIFF
--- a/pydantic_extra_types/routing_number.py
+++ b/pydantic_extra_types/routing_number.py
@@ -70,7 +70,7 @@ class ABARoutingNumber(str):
         Raises:
             PydanticCustomError: If the routing number is not all digits.
         """
-        if not routing_number.isdigit():
+        if not routing_number.isascii() or not routing_number.isdecimal():
             raise PydanticCustomError('aba_routing_number', 'routing number is not all digits')
 
     @classmethod

--- a/tests/test_routing_number.py
+++ b/tests/test_routing_number.py
@@ -39,3 +39,9 @@ def test_valid_routing_number(routing_number: str) -> None:
 def test_raises_error_when_not_a_string() -> None:
     with pytest.raises(ValidationError, match='routing number is not all digits'):
         Model(routing_number='A12210515')
+
+
+@pytest.mark.parametrize('routing_number', ['١٢٢١٠٥١٥٥', '１２２１０５１５５', '12210515²'])
+def test_rejects_non_ascii_digits(routing_number: str) -> None:
+    with pytest.raises(ValidationError, match='routing number is not all digits'):
+        Model(routing_number=routing_number)


### PR DESCRIPTION
ABA routing numbers must contain nine ASCII digits, but `str.isdigit()` also accepts Unicode numerals. Some non-ASCII values passed checksum validation and others leaked an `int()` conversion error; this validates ASCII decimal digits up front and adds regression coverage.
