### PR TITLE
fix(epoch): raise ValidationError for out-of-range timestamps

### DIFF
--- a/pydantic_extra_types/epoch.py
+++ b/pydantic_extra_types/epoch.py
@@ -35,7 +35,14 @@ class _Base(datetime.datetime):
 
     @classmethod
     def _validate(cls, __input_value: Any, _: Any) -> datetime.datetime:
-        return EPOCH + datetime.timedelta(seconds=__input_value)
+        try:
+            return EPOCH + datetime.timedelta(seconds=__input_value)
+        except (OverflowError, OSError) as e:
+            # A too-large timestamp (e.g. a JS millisecond epoch fed to a seconds field)
+            # overflows past datetime.max and raises OverflowError, which is not a
+            # ValueError subclass and so escapes as a raw exception instead of a
+            # pydantic ValidationError. Convert it so callers can handle it normally.
+            raise ValueError('timestamp is out of the supported datetime range') from e
 
     @classmethod
     def _f(cls, value: Any, serializer: Callable[[Any], Any]) -> Any:  # pragma: no cover

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -37,3 +37,15 @@ def test_schema(cls_):
 
     v = A.model_json_schema()
     assert (dt := v['properties']['dt'])['type'] == cls_.TYPE and dt['format'] == 'date-time'
+
+
+@pytest.mark.parametrize('cls_', [epoch.Integer, epoch.Number], ids=['integer', 'number'])
+def test_out_of_range_raises_validation_error(cls_):
+    # A too-large timestamp (e.g. a JS millisecond epoch accidentally fed to a seconds
+    # field) overflows past datetime.max. It must surface as a ValidationError, not a raw
+    # OverflowError that escapes validate_python.
+    from pydantic import TypeAdapter, ValidationError
+
+    ta = TypeAdapter(cls_)
+    with pytest.raises(ValidationError):
+        ta.validate_python(1_721_000_000_000)


### PR DESCRIPTION
## Change

`epoch.Integer` / `epoch.Number` compute `EPOCH + datetime.timedelta(seconds=value)` with no error handling. A timestamp past `datetime.max` — for example a JavaScript **millisecond** epoch like `1721000000000` (~mid-2024) accidentally passed to a seconds-based field — raises `OverflowError`. `OverflowError` is a subclass of `ArithmeticError`, **not** `ValueError`, so pydantic does not convert it: it escapes `validate_python` as a raw exception instead of a `ValidationError`.

## Reproduction

```python
from pydantic import TypeAdapter
from pydantic_extra_types.epoch import Integer

TypeAdapter(Integer).validate_python(253402300799)   # ok -> 9999-12-31 23:59:59+00:00
TypeAdapter(Integer).validate_python(1721000000000)  # OverflowError: date value out of range
```

A caller wrapping validation in `try/except ValidationError` (the documented pattern) will not catch this and will fault.

## Fix

Catch the overflow and raise `ValueError`, which pydantic surfaces as a `ValidationError`. Covers both `Integer` and `Number` since both go through `_Base._validate`.

## Test

Added `test_out_of_range_raises_validation_error` (parametrized over `Integer`/`Number`). Full `tests/test_epoch.py` passes (6), and `ruff format/check` + `mypy` are clean on the touched file.