### PR TITLE
fix(mongo_object_id): validate ObjectId when parsing from JSON

### DIFF
--- a/pydantic_extra_types/mongo_object_id.py
+++ b/pydantic_extra_types/mongo_object_id.py
@@ -44,17 +44,16 @@ class MongoObjectId(str):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, _: Any, __: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        from_str_schema = core_schema.no_info_after_validator_function(
+            cls.validate,
+            core_schema.str_schema(min_length=cls.OBJECT_ID_LENGTH, max_length=cls.OBJECT_ID_LENGTH),
+        )
         return core_schema.json_or_python_schema(
-            json_schema=core_schema.str_schema(min_length=cls.OBJECT_ID_LENGTH, max_length=cls.OBJECT_ID_LENGTH),
+            json_schema=from_str_schema,
             python_schema=core_schema.union_schema(
                 [
                     core_schema.is_instance_schema(ObjectId),
-                    core_schema.chain_schema(
-                        [
-                            core_schema.str_schema(min_length=cls.OBJECT_ID_LENGTH, max_length=cls.OBJECT_ID_LENGTH),
-                            core_schema.no_info_plain_validator_function(cls.validate),
-                        ]
-                    ),
+                    from_str_schema,
                 ]
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(lambda x: str(x), when_used='json'),

--- a/tests/test_mongo_object_id.py
+++ b/tests/test_mongo_object_id.py
@@ -1,6 +1,7 @@
 """Tests for the mongo_object_id module."""
 
 import pytest
+from bson import ObjectId
 from pydantic import BaseModel, GetCoreSchemaHandler, ValidationError
 from pydantic.json_schema import JsonSchemaMode
 
@@ -38,6 +39,29 @@ def test_format_for_object_id(object_id: str, result: str, valid: bool) -> None:
 
 
 @pytest.mark.parametrize(
+    'object_id, valid',
+    [
+        ('611827f2878b88b49ebb69fc', True),
+        ('z' * 24, False),  # right length, not hex
+        ('611827f2878b88b49ebb69f', False),  # too short
+    ],
+)
+def test_validate_json_matches_python(object_id: str, valid: bool) -> None:
+    """JSON validation must apply the same checks as Python validation.
+
+    The json schema only constrained the string length, so a 24-character
+    non-hex value was accepted and left as a str instead of an ObjectId.
+    """
+    payload = f'{{"object_id": "{object_id}"}}'
+
+    if valid:
+        assert MongoDocument.model_validate_json(payload).object_id == ObjectId(object_id)
+    else:
+        with pytest.raises(ValidationError):
+            MongoDocument.model_validate_json(payload)
+
+
+@pytest.mark.parametrize(
     'schema_mode',
     [
         'validation',
@@ -68,4 +92,7 @@ def test_get_pydantic_core_schema() -> None:
     assert isinstance(schema, dict)
     assert 'json_schema' in schema
     assert 'python_schema' in schema
-    assert schema['json_schema']['type'] == 'str'
+    # The JSON branch validates the string and then runs cls.validate, so the
+    # outer schema is the after-validator wrapping the length-checked str.
+    assert schema['json_schema']['type'] == 'function-after'
+    assert schema['json_schema']['schema']['type'] == 'str'


### PR DESCRIPTION
## Summary

The JSON branch of `MongoObjectId`'s core schema only constrains the string **length**:

```python
json_schema=core_schema.str_schema(min_length=24, max_length=24)
```

while the Python branch also runs `cls.validate`, which checks `ObjectId.is_valid`. A 24-character non-hex string is therefore accepted from JSON — and left as a plain `str` rather than an `ObjectId`:

```python
class M(BaseModel):
    id: MongoObjectId

M(id="z" * 24)                             # ValidationError  ✅
M.model_validate_json('{"id": "zzz…"}')    # accepted; type(m.id) is str  ❌
```

So the same value validates differently depending on the entry point, and the field's declared type is violated on the JSON path.

## Fix

Share one schema between both branches, built with an **after-validator** over the length-checked string.

The choice of `no_info_after_validator_function` over `chain_schema` matters: it keeps the underlying `str_schema` visible to the JSON Schema generator, so `model_json_schema()` is byte-identical in **both** modes. A `chain_schema` looks equivalent but breaks `mode="serialization"` with `invalid-for-json-schema` (`no_info_plain_validator_function` has no JSON Schema representation) — I hit that on the first attempt and backed it out.

## Note on the one changed assertion

`test_get_pydantic_core_schema` asserted `schema['json_schema']['type'] == 'str'` — which is precisely the shape of the bug: it pinned the JSON branch to a bare length check. I updated it to assert the after-validator wrapping the str schema, rather than dropping it:

```python
assert schema['json_schema']['type'] == 'function-after'
assert schema['json_schema']['schema']['type'] == 'str'
```

Happy to reshape this if you'd rather assert the behaviour a layer up instead of the internal schema type.

## Tests

Added a parametrized case asserting JSON validation matches Python validation (valid ObjectId, right-length-non-hex, too-short). The two invalid cases fail on `main` and pass here. The existing tests only exercised the Python path (`MongoDocument(object_id=...)`), which is why this went unnoticed.

- `pytest tests/test_mongo_object_id.py` — 10 passed
- `pytest tests/` — **13526 passed**, no regressions
- `model_json_schema()` verified unchanged in both `validation` and `serialization` mode
- `ruff check` / `ruff format --check` clean

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the full suite locally and reviewed the diff before opening.
