### PR TITLE
fix(ulid): make ULID serializable to JSON

### DIFF
--- a/pydantic_extra_types/ulid.py
+++ b/pydantic_extra_types/ulid.py
@@ -44,6 +44,7 @@ class ULID(_repr.Representation):
                     core_schema.uuid_schema(),
                 ]
             ),
+            serialization=core_schema.plain_serializer_function_ser_schema(str, when_used='json'),
         )
 
     @classmethod

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -95,3 +95,18 @@ def test_json_schema():
         'title': 'Something',
         'type': 'object',
     }
+
+
+def test_json_serialization():
+    """A ULID field must be serializable to JSON.
+
+    The schema advertises integer/string/binary/uuid in serialization mode, but
+    the union's leading is_instance_schema carried no serializer, so
+    model_dump_json raised PydanticSerializationError.
+    """
+    something = Something(ulid='01BTGNYV6HRNK8K8VKZASZCFPE')
+
+    assert something.model_dump_json() == '{"ulid":"01BTGNYV6HRNK8K8VKZASZCFPE"}'
+    assert Something.model_validate_json(something.model_dump_json()).ulid == something.ulid
+    # Python mode still yields the underlying ULID object, not a string
+    assert isinstance(something.model_dump()['ulid'], _ULID)


### PR DESCRIPTION
## Summary

A `ULID` field cannot be serialized to JSON at all:

```python
class Something(BaseModel):
    ulid: ULID

Something(ulid="01BTGNYV6HRNK8K8VKZASZCFPE").model_dump_json()
# PydanticSerializationError: Unable to serialize unknown type: <class 'ulid.ULID'>
```

`model_dump()` works (it returns the underlying `ulid.ULID` object), but any JSON path — `model_dump_json()`, a FastAPI response, `TypeAdapter.dump_json` — raises.

**The published schema says otherwise.** `test_json_schema` already asserts that `mode="serialization"` advertises `integer` / `string` / `binary` / `uuid`:

```python
assert Something.model_json_schema(mode='serialization') == {
    'properties': {'ulid': {'anyOf': [{'type': 'integer'}, {'format': 'binary', 'type': 'string'},
                                      {'type': 'string'}, {'format': 'uuid', 'type': 'string'}], ...}}, ...}
```

So the schema promises something the runtime cannot deliver — anything generating an OpenAPI spec from this type is advertising a serialization that raises.

## Cause

`__get_pydantic_core_schema__` only wires up validation. After `_validate_ulid` the value is a python-ulid `ULID` instance, and the union's leading `is_instance_schema(_ULID)` carries no serializer, so pydantic has nothing to render it with.

## Fix

Add a json serializer, matching the convention `MongoObjectId` already uses in this repo:

```python
serialization=core_schema.plain_serializer_function_ser_schema(str, when_used='json'),
```

`when_used='json'` keeps Python mode untouched — `model_dump()` still yields the `ULID` object, so nothing that relies on that changes. The serialization json schema is also unchanged (verified against the existing `test_json_schema` assertion).

## Tests

Added a case asserting `model_dump_json()` produces the canonical string, that it round-trips back through `model_validate_json`, and that Python mode still yields the object. It fails on `main` with the `PydanticSerializationError` and passes here. No existing test exercised `model_dump_json` on a ULID field, which is why the gap between the advertised schema and the runtime went unnoticed.

- `pytest tests/test_ulid.py` — 18 passed
- `pytest tests/` — 13524 passed (baseline 13523 + 1 new), no regressions
- `ruff check` / `ruff format --check` clean

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the test. I ran the repro and the full suite locally and reviewed the diff before opening.
