### PR TITLE
fix(pendulum_dt): preserve Interval boundaries on JSON serialization

### DIFF
--- a/pydantic_extra_types/pendulum_dt.py
+++ b/pydantic_extra_types/pendulum_dt.py
@@ -406,7 +406,14 @@ class Interval(_Interval[Any]):
         Returns:
             A Pydantic CoreSchema with the Interval validation.
         """
-        return core_schema.no_info_wrap_validator_function(cls._validate, core_schema.str_schema())
+        return core_schema.no_info_wrap_validator_function(
+            cls._validate,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda instance: f'{instance.start.isoformat()}/{instance.end.isoformat()}',
+                when_used='json-unless-none',
+            ),
+        )
 
     @classmethod
     def _instance(cls, value: _Interval[Any]) -> Interval:

--- a/tests/test_pendulum_dt.py
+++ b/tests/test_pendulum_dt.py
@@ -317,6 +317,30 @@ def test_pendulum_interval_from_serialized():
 
 
 @pytest.mark.parametrize(
+    'interval_str',
+    [
+        '2024-01-01T00:00:00+00:00/2024-01-02T00:00:00+00:00',
+        '2021-05-06T12:30:00+00:00/2021-05-06T13:45:30+00:00',
+        '2020-02-28T00:00:00+00:00/2020-03-01T00:00:00+00:00',
+    ],
+)
+def test_pendulum_interval_serialization_roundtrip(interval_str):
+    """Verifies that an Interval survives a JSON serialize/deserialize round-trip.
+
+    Regression: without a serialization schema the Interval was serialized as a
+    bare duration (e.g. ``"P1D"``), dropping the start/end boundaries, and the
+    resulting string then failed to re-validate.
+    """
+    adapter = TypeAdapter(Interval)
+    interval = adapter.validate_python(interval_str)
+    json_serialized = adapter.dump_json(interval)
+    deserialized = adapter.validate_json(json_serialized)
+    assert deserialized.start == interval.start
+    assert deserialized.end == interval.end
+    assert deserialized == interval
+
+
+@pytest.mark.parametrize(
     'duration',
     [
         Duration(months=1),


### PR DESCRIPTION
## Summary

`Interval` fails to round-trip through JSON: serializing loses data and the result won't re-validate.

`Interval.__get_pydantic_core_schema__` wraps the validator around a bare `str_schema()` with no `serialization` schema. Because an `Interval` subclasses `Duration`/`timedelta`, pydantic-core serializes it via the duration path and emits only the interval's *length* — e.g. `"P1D"` — discarding the `start`/`end` boundaries. Deserializing that string then raises `ValidationError`.

```python
from pydantic import TypeAdapter
from pydantic_extra_types.pendulum_dt import Interval

ta = TypeAdapter(Interval)
i = ta.validate_python("2021-01-01T00:00:00+00:00/2021-01-02T00:00:00+00:00")
j = ta.dump_json(i)      # b'"P1D"'  (+ serializer warning) — start/end lost
ta.validate_json(j)      # ValidationError: value is not a valid interval
```

The sibling types (`DateTime`, `Date`, `Duration`, `Time`) all round-trip correctly; only `Interval` was missing a serialization schema.

## Fix

Add a serializer that emits the `start/end` ISO form the validator already accepts, mirroring `Duration`'s `plain_serializer_function_ser_schema(..., when_used='json-unless-none')`. `model_dump_json()` now yields `"2021-01-01T00:00:00+00:00/2021-01-02T00:00:00+00:00"`, which re-validates to an equal `Interval`. Python-mode `model_dump()` is unchanged (still returns the `Interval` object).

## Tests

Added a parametrized JSON round-trip regression test (`test_pendulum_interval_serialization_roundtrip`), matching the existing `test_pendulum_duration_serialization_roundtrip`. It is red before the fix (the serialized `"P1D"` fails to re-validate) and green after. Full suite: 13526 passed; `ruff format`/`ruff check`/`mypy` clean.

---
*Disclosure: prepared with AI assistance (Claude Code). I reproduced the bug against `main`, verified the fix and the full suite, and reviewed the diff before opening.*
