### PR TITLE
fix(isbn, iban, mac_address): raise ValidationError for non-string input

### DIFF
--- a/pydantic_extra_types/iban.py
+++ b/pydantic_extra_types/iban.py
@@ -147,7 +147,10 @@ class IBAN(str):
         )
 
     @classmethod
-    def _validate(cls, __input_value: str, _: Any) -> IBAN:
+    def _validate(cls, __input_value: Any, _: Any) -> IBAN:
+        if not isinstance(__input_value, str):
+            raise PydanticCustomError('iban_type', 'Value must be a string')
+
         # Remove spaces and convert to uppercase
         iban = __input_value.replace(' ', '').upper()
 

--- a/pydantic_extra_types/isbn.py
+++ b/pydantic_extra_types/isbn.py
@@ -80,11 +80,11 @@ class ISBN(str):
         )
 
     @classmethod
-    def _validate(cls, __input_value: str, _: Any) -> str:
-        """Validate a ISBN from the provided str value.
+    def _validate(cls, __input_value: Any, _: Any) -> str:
+        """Validate a ISBN from the provided value.
 
         Args:
-            __input_value: The str value to be validated.
+            __input_value: The value to be validated.
             _: The source type to be converted.
 
         Returns:
@@ -93,6 +93,9 @@ class ISBN(str):
         Raises:
             PydanticCustomError: If the ISBN is not valid.
         """
+        if not isinstance(__input_value, str):
+            raise PydanticCustomError('isbn_type', 'Value must be a string')
+
         cls.validate_isbn_format(__input_value)
 
         return cls.convert_isbn10_to_isbn13(__input_value)

--- a/pydantic_extra_types/mac_address.py
+++ b/pydantic_extra_types/mac_address.py
@@ -50,17 +50,20 @@ class MacAddress(str):
         )
 
     @classmethod
-    def _validate(cls, __input_value: str, _: Any) -> str:
-        """Validate a MAC Address from the provided str value.
+    def _validate(cls, __input_value: Any, _: Any) -> str:
+        """Validate a MAC Address from the provided value.
 
         Args:
-            __input_value: The str value to be validated.
+            __input_value: The value to be validated.
             _: The source type to be converted.
 
         Returns:
             str: The parsed MAC address.
 
         """
+        if not isinstance(__input_value, str):
+            raise PydanticCustomError('mac_address_type', 'Value must be a string')
+
         return cls.validate_mac_address(__input_value.encode())
 
     @staticmethod

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from pydantic import BaseModel, ValidationError
 
@@ -104,3 +106,9 @@ def test_iban_normalizes_spaces_and_case() -> None:
     account = BankAccount(iban='gb29 nwbk 6016 1331 9268 19')
     assert account.iban == 'GB29NWBK60161331926819'
     assert isinstance(account.iban, str)
+
+
+@pytest.mark.parametrize('iban_value', [None, 12345, 1.5, b'bytes', [], {}])
+def test_iban_requires_string(iban_value: Any) -> None:
+    with pytest.raises(ValidationError, match='Value must be a string'):
+        BankAccount(iban=iban_value)

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -153,3 +153,9 @@ isbn_conversion_test_cases = [
 @pytest.mark.parametrize('input_isbn, output_isbn', isbn_conversion_test_cases)
 def test_isbn_conversion(input_isbn: Any, output_isbn: str) -> None:
     assert Book(isbn=ISBN(input_isbn)).isbn == output_isbn
+
+
+@pytest.mark.parametrize('isbn_value', [None, 12345, 1.5, b'bytes', [], {}])
+def test_isbn_requires_string(isbn_value: Any) -> None:
+    with pytest.raises(ValidationError, match='Value must be a string'):
+        Book(isbn=isbn_value)

--- a/tests/test_mac_address.py
+++ b/tests/test_mac_address.py
@@ -142,3 +142,9 @@ def test_model_validation():
             'type': 'mac_address_len',
         }
     ]
+
+
+@pytest.mark.parametrize('mac_address_value', [None, 12345, 1.5, b'bytes', [], {}])
+def test_mac_address_requires_string(mac_address_value: Any) -> None:
+    with pytest.raises(ValidationError, match='Value must be a string'):
+        Network(mac_address=mac_address_value)


### PR DESCRIPTION
## Summary

`ISBN`, `IBAN` and `MacAddress` register `_validate` as a **before** validator, so it runs ahead of `str_schema()` and receives the raw input. Each then calls a str-only method on it, so a non-string leaks out of validation instead of raising `ValidationError`:

```python
Book(isbn=9780306406157)     # TypeError: object of type 'int' has no len()
BankAccount(iban=12345)      # AttributeError: 'int' object has no attribute 'replace'
Network(mac_address=12345)   # AttributeError: 'int' object has no attribute 'encode'
```

`except ValidationError` does not catch these, so an int id, or a missing field arriving as `None`, crashes past the validation boundary instead of being reported as a validation error.

## Fix

There are four `with_info_before_validator_function` types. `DomainStr` is the one that gets it right:

```python
def _validate(cls, v: Any) -> DomainStr:
    if not isinstance(v, str):
        raise PydanticCustomError('domain_type', 'Value must be a string')
```

It annotates the input as `Any` — the truth for a before-validator — and checks. The other three annotate it as `str` and omit the check. This applies `DomainStr`'s pattern to each, following its message and error-type naming.

The 14 **after**-validator types (`ISIN`, `routing_number`, `payment`, …) are unaffected: `str_schema()` rejects non-strings before their `_validate` runs. `test_isin_requires_string` already asserts this contract, which is why it's the contract I matched.

**Return types are unchanged**, which is the reason for this route rather than the obvious alternative. Switching these three to after-validators (converging with the other 14) also fixes the bug — but it changes what `model_dump()` yields for `isbn`/`iban` from `str` to `ISBN`/`IBAN`. That felt like a separate decision, so this PR takes the `DomainStr` route, which is inert in that respect. Happy to switch if you'd rather converge on after-validators.

## On `MacAddress`

`test_format_for_mac_address` already carries `b'12.!4.5!.7/.#G.AB......'` and `float(12345678910111213)` as cases expecting `valid=False`, so the intent is on record. But the test body calls `MacAddress(mac_address)` first, and since `MacAddress` subclasses `str`, that stringifies the input before it reaches the validator — `MacAddress(b'12.!4')` is the *string* `"b'12.!4'"`. The non-string path those two cases were written for has never actually been exercised. Passing them the way a caller would, `Network(mac_address=b'...')`, gives `AttributeError` today.

I left that test as it is; the new tests cover the path directly.

## Tests

Repro against unmodified `main`, with `ISIN` and `DomainStr` as controls on the same inputs:

```
isbn         int:TypeError       None:TypeError       bytes:TypeError       float:TypeError
iban         int:AttributeError  None:AttributeError  bytes:AttributeError  float:AttributeError
mac_address  int:AttributeError  None:AttributeError  bytes:AttributeError  float:AttributeError
isin         int:ValidationError None:ValidationError bytes:ValidationError float:ValidationError  <- control
domain       int:ValidationError None:ValidationError bytes:ValidationError float:ValidationError  <- control
```

After the fix, all three broken rows look like the control rows.

Added `test_{isbn,iban,mac_address}_requires_string`, modelled on `test_invalid_domain_types`. Red before the fix (18 failures across the three parametrized cases), green after. Full suite `13548 passed`, no failures. `ruff check` / `ruff format` / `mypy` clean.

---

**Disclosure: this contribution is fully AI-authored and autonomous** (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the tests, and wrote this description; the human operator of this account did not hand-review the diff or run the tests. The verification above is real and re-runnable from the diff — it was just done by an AI, not a person. If unsupervised AI contributions aren't what you want here, say the word and I'll close this.
