### PR TITLE
fix(ulid, color): raise ValidationError for types float()/from_bytes reject

### DIFF
--- a/pydantic_extra_types/color.py
+++ b/pydantic_extra_types/color.py
@@ -388,7 +388,7 @@ def parse_float_alpha(value: None | str | float | int) -> float | None:
             alpha = float(value[:-1]) / 100
         else:
             alpha = float(value)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
         raise PydanticCustomError(
             'color_error',
             'value is not a valid color: alpha values must be a valid float',

--- a/pydantic_extra_types/ulid.py
+++ b/pydantic_extra_types/ulid.py
@@ -63,6 +63,6 @@ class ULID(_repr.Representation):
                 ulid = value
             else:
                 ulid = _ULID.from_bytes(value)
-        except ValueError as e:
+        except (ValueError, TypeError) as e:
             raise PydanticCustomError('ulid_format', 'Unrecognized format') from e
         return handler(ulid)

--- a/tests/test_types_color.py
+++ b/tests/test_types_color.py
@@ -86,6 +86,9 @@ def test_color_success(raw_color, as_tuple):
         (0, 0, 'x'),
         (0, 0, 0, 1.5),
         (0, 0, 0, 'x'),
+        # Alpha types float() cannot take at all: a ValidationError, not a raw TypeError
+        (0, 0, 0, []),
+        (0, 0, 0, {}),
         (0, 0, 1280),
         (0, 0, 1205, 0.1),
         (0, 0, 1128, 0.5),

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -44,6 +44,11 @@ class Something(BaseModel):
         # Invalid ULID for bool format
         (True, None, False),
         (False, None, False),
+        # Types _ULID cannot construct from: must be a ValidationError, not a raw TypeError
+        (1.5, None, False),
+        (None, None, False),
+        ([], None, False),
+        ({}, None, False),
     ],
 )
 def test_format_for_ulid(ulid: Any, result: Any, valid: bool):


### PR DESCRIPTION
## Summary

#312 widened `except ValueError` to `except (ValueError, TypeError)` in `color.py` to fix #311 *"Unhandled validation error when parsing Color"* — because `float()` raises `TypeError`, not `ValueError`, for a value whose *type* it cannot take at all.

Two call sites with the identical construct weren't updated:

```python
Something(ulid=1.5)     # TypeError: object of type 'float' has no len()
Color((0, 0, 0, []))    # TypeError: float() argument must be a string or a real number, not 'list'
```

`TypeError` is not a subclass of `ValueError`, so neither `except` fires and the error escapes `validate_python` raw. A caller using the documented `try/except ValidationError` faults instead of catching.

## Fix

The same one-line widening as #312, at each site, reusing the error each one already raises.

- **`ulid.py:66`** — `_validate_ulid` is a *wrap* validator, so it receives the raw value before the inner `union_schema([_ULID, int, bytes, str, uuid])` can reject anything. Anything that isn't one of those falls to the `else` branch and reaches `_ULID.from_bytes`.
- **`color.py:391`** — `parse_float_alpha`'s own docstring says it raises `PydanticCustomError` *"If the input value cannot be successfully parsed as a float in the expected range"*. A `list` cannot be. `None` is handled separately at `:384` and still returns `None`; this only affects types `float()` refuses outright.

## Tests

Repro against unmodified `main`, with `Color`'s already-fixed path as the control — same disease, one site cured by #312, one not:

```
input        ULID (ulid.py:66)      Color str/float parsing (#312, fixed)
1.5          raw TypeError          ValidationError
None         raw TypeError          ValidationError
[]           raw TypeError          ValidationError
{}           raw TypeError          ValidationError
('a','b')    raw TypeError          ValidationError
```

And the alpha path specifically, before → after:

```
(0,0,0,[])      raw TypeError        -> ValidationError (color_error)
(0,0,0,{})      raw TypeError        -> ValidationError (color_error)
(0,0,0,'x')     ValidationError      -> unchanged   # the ValueError path
(1,2,3,None)    #010203              -> unchanged   # None alpha stays valid
(1,2,3,0.5)     #01020380            -> unchanged
```

Cases appended to the existing `test_format_for_ulid` and `test_color_fail` parameter lists — the latter right beside `(0, 0, 0, 'x')`, its `ValueError` sibling, and where #312 put `({}, 0, 0)`.

Red before the fix (6 failures), green after. Full suite `13536 passed`, no failures. `model_json_schema()` byte-identical in both `validation` and `serialization` modes; return types and `model_dump_json()` unchanged. `ruff check` / `ruff format` / `mypy` clean.

## Note on overlap with #408

#408 (open) also turns raw exceptions into `ValidationError`, so the two look related — they aren't the same bug, and I'd rather say so than have you find out mid-review:

- **#408** — `ISBN`/`IBAN`/`MacAddress` are *before* validators that call str-only methods on the raw input without the `isinstance` guard `DomainStr` has. No `except` clause involved.
- **this PR** — the `except` clause is too narrow at two sites, and #312 already settled that question for this file.

Different mechanism, no file overlap, and each stands alone. Happy to fold them if you'd rather review once.

---

**Disclosure: this contribution is fully AI-authored and autonomous** (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the tests, and wrote this description; the human operator of this account did not hand-review the diff or run the tests. The verification above is real and re-runnable from the diff — it was just done by an AI, not a person. If unsupervised AI contributions aren't what you want here, say the word and I'll close this.
