### PR TITLE
fix(isin, isbn, iban): reject non-ASCII digits

### DIFF
--- a/pydantic_extra_types/iban.py
+++ b/pydantic_extra_types/iban.py
@@ -187,7 +187,7 @@ class IBAN(str):
             )
 
         # Check that remaining characters are alphanumeric
-        if not iban[2:].isalnum():
+        if not iban[2:].isascii() or not iban[2:].isalnum():
             raise PydanticCustomError(
                 'iban_invalid_characters',
                 'Invalid IBAN: must contain only alphanumeric characters',

--- a/pydantic_extra_types/isbn.py
+++ b/pydantic_extra_types/isbn.py
@@ -116,13 +116,17 @@ class ISBN(str):
             raise PydanticCustomError('isbn_length', f'Length for ISBN must be 10 or 13 digits, not {isbn_length}')
 
         if isbn_length == 10:
-            if not value[:-1].isdigit() or ((value[-1] != 'X') and (not value[-1].isdigit())):
+            if (
+                not value[:-1].isascii()
+                or not value[:-1].isdigit()
+                or ((value[-1] != 'X') and (not value[-1].isascii() or not value[-1].isdigit()))
+            ):
                 raise PydanticCustomError('isbn10_invalid_characters', 'First 9 digits of ISBN-10 must be integers')
             if isbn10_digit_calc(value) != value[-1]:
                 raise PydanticCustomError('isbn_invalid_digit_check_isbn10', 'Provided digit is invalid for given ISBN')
 
         if isbn_length == 13:
-            if not value.isdigit():
+            if not value.isascii() or not value.isdigit():
                 raise PydanticCustomError('isbn13_invalid_characters', 'All digits of ISBN-13 must be integers')
             if value[:3] not in ('978', '979'):
                 raise PydanticCustomError(

--- a/pydantic_extra_types/isin.py
+++ b/pydantic_extra_types/isin.py
@@ -127,7 +127,7 @@ class ISIN(str):
         if isin_length != 12:
             raise PydanticCustomError('isin_length', f'Length for ISIN must be 12 characters, not {isin_length}')
 
-        if not value.isalnum():
+        if not value.isascii() or not value.isalnum():
             raise PydanticCustomError('isin_invalid_characters', 'All characters of ISIN must be letters or digits')
 
         if not value[:2].isalpha():

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -112,3 +112,9 @@ def test_iban_normalizes_spaces_and_case() -> None:
 def test_iban_requires_string(iban_value: Any) -> None:
     with pytest.raises(ValidationError, match='Value must be a string'):
         BankAccount(iban=iban_value)
+
+
+@pytest.mark.parametrize('iban', ['GB29NWBK٦0161331926819', 'GB29NWBK6016133192681²'])
+def test_iban_rejects_non_ascii_digits(iban: str) -> None:
+    with pytest.raises(ValidationError, match='iban_invalid_characters'):
+        BankAccount(iban=iban)

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -159,3 +159,15 @@ def test_isbn_conversion(input_isbn: Any, output_isbn: str) -> None:
 def test_isbn_requires_string(isbn_value: Any) -> None:
     with pytest.raises(ValidationError, match='Value must be a string'):
         Book(isbn=isbn_value)
+
+
+@pytest.mark.parametrize('isbn_value', ['97885٣7809662', '97885３7809662', '978853780966²'])
+def test_isbn13_rejects_non_ascii_digits(isbn_value: str) -> None:
+    with pytest.raises(ValidationError, match='isbn13_invalid_characters'):
+        Book(isbn=isbn_value)
+
+
+@pytest.mark.parametrize('isbn_value', ['08044295٧X', '0804４2957X'])
+def test_isbn10_rejects_non_ascii_digits(isbn_value: str) -> None:
+    with pytest.raises(ValidationError, match='isbn10_invalid_characters'):
+        Book(isbn=isbn_value)

--- a/tests/test_isin.py
+++ b/tests/test_isin.py
@@ -62,3 +62,9 @@ def test_isin_invalid_check_digit(input_isin: str) -> None:
 def test_isin_requires_string(isin_value: Any) -> None:
     with pytest.raises(ValidationError, match='Input should be a valid string'):
         Security(isin=isin_value)
+
+
+@pytest.mark.parametrize('isin_value', ['US03783२1005', 'US037833100٥', 'US037833100²'])
+def test_isin_rejects_non_ascii_digits(isin_value: str) -> None:
+    with pytest.raises(ValidationError, match='isin_invalid_characters'):
+        Security(isin=isin_value)


### PR DESCRIPTION
## Summary

`str.isdigit()` / `str.isalnum()` return `True` for non-ASCII numerals (Arabic-Indic `٠-٩`, fullwidth `０-９`, …), and `int('٥') == 5`, so the checksum still validates. As a result `ISIN`, `ISBN` and `IBAN` each accepted "validated" identifiers that contain non-ASCII characters and violate their ISO standards:

```python
TypeAdapter(ISIN).validate_python("US037833100٥")           # -> ISIN('US037833100٥')
TypeAdapter(ISBN).validate_python("97885٣7809662")          # -> ISBN('97885٣7809662')
TypeAdapter(ISBN).validate_python("85٣7809667")             # ISBN-10 -> ISBN('97885٣7809662')  (still non-ASCII)
TypeAdapter(IBAN).validate_python("GB29NWBK٦0161331926819") # -> IBAN('GB29NWBK٦0161331926819')
```

ISO 6166 (ISIN), the ISBN spec, and ISO 13616 (IBAN) all restrict these identifiers to ASCII `[A-Z0-9]` (plus `X` for the ISBN-10 check digit).

## Fix

Guard each character check with `str.isascii()`, mirroring the fix already applied to the sibling `ABARoutingNumber` in #403 (and the `'0' <= c <= '9'` guard `PaymentCardNumber` already uses). Superscript digits such as `²` (where `isdigit()` is `True` but `int()` raises) are covered by the same guard, so they no longer leak a raw `invalid literal for int()` message.

Legitimate ASCII identifiers are unaffected — including the ISBN-10 check digit `X` — and the existing test suites stay green. Added parametrized rejection tests (Arabic-Indic, fullwidth, superscript) to each type, in the same style as #403.

---

*AI disclosure: this change was authored end-to-end by an AI agent (Claude Code, on this account) — it found the three sibling types, wrote the guards and tests, and ran the verification below; the human account holder reviews every change and is accountable for it. Verified: each type accepts the non-ASCII inputs before the change and rejects them after; the new tests fail without the guard and pass with it; full `pytest` suite green (13615 passed); `ruff check`/`format` and `mypy` clean.*

