### PR TITLE
feat: add PandasDataFrame and PandasSeries types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
       prefix: ⬆
     cooldown:
       default-days: 7
-  # Python
   - package-ecosystem: 'uv'
+    # Python
     directory: '/'
     schedule:
       interval: 'monthly'

--- a/pydantic_extra_types/pandas.py
+++ b/pydantic_extra_types/pandas.py
@@ -14,7 +14,7 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import PydanticCustomError, core_schema
 
 try:
-    import pandas as pd
+    import pandas as pd  # type: ignore[import-untyped]
 except ModuleNotFoundError as e:
     raise RuntimeError(
         '`PandasDataFrame` requires "pandas" to be installed. You can install it with "pip install pandas"'

--- a/pydantic_extra_types/pandas.py
+++ b/pydantic_extra_types/pandas.py
@@ -17,8 +17,7 @@ try:
     import pandas as pd
 except ModuleNotFoundError as e:
     raise RuntimeError(
-        '`PandasDataFrame` requires "pandas" to be installed. '
-        'You can install it with "pip install pandas"'
+        '`PandasDataFrame` requires "pandas" to be installed. You can install it with "pip install pandas"'
     ) from e
 
 
@@ -92,9 +91,7 @@ class PandasDataFrame:
     """An optional list of column names that the DataFrame must contain."""
 
     @classmethod
-    def __get_pydantic_core_schema__(
-        cls, source: type[Any], handler: GetCoreSchemaHandler
-    ) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         return core_schema.with_info_after_validator_function(
             cls._validate,
             core_schema.any_schema(),
@@ -175,9 +172,7 @@ class PandasDataFrameValidator:
     required_columns: list[str] | None = None
     """An optional list of column names that the DataFrame must contain."""
 
-    def __get_pydantic_core_schema__(
-        self, source: type[Any], handler: GetCoreSchemaHandler
-    ) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(self, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         return core_schema.no_info_before_validator_function(
             partial(
                 _validate_dataframe,
@@ -219,9 +214,7 @@ class PandasSeries:
     """
 
     @classmethod
-    def __get_pydantic_core_schema__(
-        cls, source: type[Any], handler: GetCoreSchemaHandler
-    ) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         return core_schema.with_info_after_validator_function(
             cls._validate,
             core_schema.any_schema(),

--- a/pydantic_extra_types/pandas.py
+++ b/pydantic_extra_types/pandas.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
-from pydantic import GetCoreSchemaHandler
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import PydanticCustomError, core_schema
 
 try:
@@ -99,7 +99,7 @@ class PandasDataFrame:
 
     @classmethod
     def __get_pydantic_json_schema__(
-        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
+        cls, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> dict[str, Any]:
         json_schema = handler(schema)
         json_schema.update({'type': 'object', 'title': 'DataFrame'})
@@ -183,7 +183,7 @@ class PandasDataFrameValidator:
 
     @classmethod
     def __get_pydantic_json_schema__(
-        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
+        cls, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> dict[str, Any]:
         json_schema = handler(schema)
         json_schema.update({'type': 'object', 'title': 'DataFrame'})
@@ -222,7 +222,7 @@ class PandasSeries:
 
     @classmethod
     def __get_pydantic_json_schema__(
-        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
+        cls, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> dict[str, Any]:
         json_schema = handler(schema)
         json_schema.update({'type': 'array', 'title': 'Series'})

--- a/pydantic_extra_types/pandas.py
+++ b/pydantic_extra_types/pandas.py
@@ -1,0 +1,325 @@
+"""The `pydantic_extra_types.pandas` module provides the
+[`PandasDataFrame`][pydantic_extra_types.pandas.PandasDataFrame] data type.
+
+This class depends on the [pandas](https://pypi.org/project/pandas/) package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from typing import Any
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import PydanticCustomError, core_schema
+
+try:
+    import pandas as pd
+except ModuleNotFoundError as e:
+    raise RuntimeError(
+        '`PandasDataFrame` requires "pandas" to be installed. '
+        'You can install it with "pip install pandas"'
+    ) from e
+
+
+class PandasDataFrame:
+    """A wrapper type that validates an object is a `pandas.DataFrame`.
+
+    You can optionally require a set of columns to be present in the
+    DataFrame by setting `required_columns` either via subclassing or
+    by using the [`PandasDataFrameValidator`][pydantic_extra_types.pandas.PandasDataFrameValidator]
+    annotation.
+
+    ## Examples
+
+    ### Basic usage:
+
+    ```python
+    import pandas as pd
+    from pydantic import BaseModel
+    from pydantic_extra_types.pandas import PandasDataFrame
+
+
+    class Model(BaseModel):
+        df: PandasDataFrame
+
+
+    m = Model(df=pd.DataFrame({'a': [1, 2, 3]}))
+    print(m.df)
+    ```
+
+    ### With required columns via subclassing:
+
+    ```python
+    import pandas as pd
+    from pydantic import BaseModel
+    from pydantic_extra_types.pandas import PandasDataFrame
+
+
+    class UserFrame(PandasDataFrame):
+        required_columns = ['name', 'email']
+
+
+    class Model(BaseModel):
+        df: UserFrame
+
+
+    # This will raise a validation error because 'email' is missing
+    m = Model(df=pd.DataFrame({'name': ['Alice']}))
+    ```
+
+    ### With required columns via annotation:
+
+    ```python
+    from typing import Annotated
+    import pandas as pd
+    from pydantic import BaseModel
+    from pydantic_extra_types.pandas import PandasDataFrameValidator
+
+    UserFrame = Annotated[pd.DataFrame, PandasDataFrameValidator(required_columns=['name', 'email'])]
+
+
+    class Model(BaseModel):
+        df: UserFrame
+
+
+    m = Model(df=pd.DataFrame({'name': ['Alice'], 'email': ['alice@example.com']}))
+    print(m.df)
+    ```
+    """
+
+    required_columns: list[str] | None = None
+    """An optional list of column names that the DataFrame must contain."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.with_info_after_validator_function(
+            cls._validate,
+            core_schema.any_schema(),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
+    ) -> dict[str, Any]:
+        json_schema = handler(schema)
+        json_schema.update({'type': 'object', 'title': 'DataFrame'})
+        return json_schema
+
+    @classmethod
+    def _validate(cls, value: Any, _: core_schema.ValidationInfo) -> pd.DataFrame:
+        if not isinstance(value, pd.DataFrame):
+            raise PydanticCustomError(
+                'value_error',
+                'value is not a valid pandas DataFrame',
+            )
+
+        if cls.required_columns:
+            missing = [col for col in cls.required_columns if col not in value.columns]
+            if missing:
+                raise PydanticCustomError(
+                    'value_error',
+                    'DataFrame is missing required columns: {}'.format(', '.join(missing)),
+                )
+
+        return value
+
+
+def _validate_dataframe(
+    required_columns: list[str] | None,
+    value: Any,
+) -> pd.DataFrame:
+    """Validate that *value* is a ``pd.DataFrame`` and (optionally) that it
+    contains *required_columns*."""
+    if not isinstance(value, pd.DataFrame):
+        raise PydanticCustomError(
+            'value_error',
+            'value is not a valid pandas DataFrame',
+        )
+
+    if required_columns:
+        missing = [col for col in required_columns if col not in value.columns]
+        if missing:
+            raise PydanticCustomError(
+                'value_error',
+                'DataFrame is missing required columns: {}'.format(', '.join(missing)),
+            )
+
+    return value
+
+
+from dataclasses import dataclass
+from functools import partial
+
+
+@dataclass(frozen=True)
+class PandasDataFrameValidator:
+    """An annotation to validate `pd.DataFrame` objects with column constraints.
+
+    Example:
+        ```python
+        from typing import Annotated
+        import pandas as pd
+        from pydantic import BaseModel
+        from pydantic_extra_types.pandas import PandasDataFrameValidator
+
+        UserFrame = Annotated[pd.DataFrame, PandasDataFrameValidator(required_columns=['name', 'email'])]
+
+
+        class Model(BaseModel):
+            df: UserFrame
+
+
+        m = Model(df=pd.DataFrame({'name': ['Alice'], 'email': ['alice@example.com']}))
+        ```
+    """
+
+    required_columns: list[str] | None = None
+    """An optional list of column names that the DataFrame must contain."""
+
+    def __get_pydantic_core_schema__(
+        self, source: type[Any], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_before_validator_function(
+            partial(
+                _validate_dataframe,
+                self.required_columns,
+            ),
+            core_schema.any_schema(),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
+    ) -> dict[str, Any]:
+        json_schema = handler(schema)
+        json_schema.update({'type': 'object', 'title': 'DataFrame'})
+        return json_schema
+
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+
+class PandasSeries:
+    """A wrapper type that validates an object is a `pandas.Series`.
+
+    ## Examples
+
+    ```python
+    import pandas as pd
+    from pydantic import BaseModel
+    from pydantic_extra_types.pandas import PandasSeries
+
+
+    class Model(BaseModel):
+        s: PandasSeries
+
+
+    m = Model(s=pd.Series([1, 2, 3]))
+    print(m.s)
+    ```
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.with_info_after_validator_function(
+            cls._validate,
+            core_schema.any_schema(),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
+    ) -> dict[str, Any]:
+        json_schema = handler(schema)
+        json_schema.update({'type': 'array', 'title': 'Series'})
+        return json_schema
+
+    @classmethod
+    def _validate(cls, value: Any, _: core_schema.ValidationInfo) -> pd.Series:
+        if not isinstance(value, pd.Series):
+            raise PydanticCustomError(
+                'value_error',
+                'value is not a valid pandas Series',
+            )
+
+        return value
+
+
+from dataclasses import dataclass
+from functools import partial
+
+
+@dataclass(frozen=True)
+class PandasDataFrameValidator:
+    """An annotation to validate `pd.DataFrame` objects with column constraints.
+
+    Example:
+        ```python
+        from typing import Annotated
+        import pandas as pd
+        from pydantic import BaseModel
+        from pydantic_extra_types.pandas import PandasDataFrameValidator
+
+        UserFrame = Annotated[pd.DataFrame, PandasDataFrameValidator(required_columns=['name', 'email'])]
+
+
+        class Model(BaseModel):
+            df: UserFrame
+
+
+        m = Model(df=pd.DataFrame({'name': ['Alice'], 'email': ['alice@example.com']}))
+        ```
+    """
+
+    required_columns: list[str] | None = None
+    """An optional list of column names that the DataFrame must contain."""
+
+    def __get_pydantic_core_schema__(
+        self, source: type[Any], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_before_validator_function(
+            partial(
+                _validate_dataframe,
+                self.required_columns,
+            ),
+            core_schema.any_schema(),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
+    ) -> dict[str, Any]:
+        json_schema = handler(schema)
+        json_schema.update({'type': 'object', 'title': 'DataFrame'})
+        return json_schema
+
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+
+def _validate_dataframe(
+    required_columns: list[str] | None,
+    value: Any,
+) -> pd.DataFrame:
+    """Validate that *value* is a ``pd.DataFrame`` and (optionally) that it
+    contains *required_columns*."""
+    if not isinstance(value, pd.DataFrame):
+        raise PydanticCustomError(
+            'value_error',
+            'value is not a valid pandas DataFrame',
+        )
+
+    if required_columns:
+        missing = [col for col in required_columns if col not in value.columns]
+        if missing:
+            raise PydanticCustomError(
+                'value_error',
+                'DataFrame is missing required columns: {}'.format(', '.join(missing)),
+            )
+
+    return value

--- a/pydantic_extra_types/pandas.py
+++ b/pydantic_extra_types/pandas.py
@@ -150,10 +150,6 @@ def _validate_dataframe(
     return value
 
 
-from dataclasses import dataclass
-from functools import partial
-
-
 @dataclass(frozen=True)
 class PandasDataFrameValidator:
     """An annotation to validate `pd.DataFrame` objects with column constraints.
@@ -248,78 +244,3 @@ class PandasSeries:
             )
 
         return value
-
-
-from dataclasses import dataclass
-from functools import partial
-
-
-@dataclass(frozen=True)
-class PandasDataFrameValidator:
-    """An annotation to validate `pd.DataFrame` objects with column constraints.
-
-    Example:
-        ```python
-        from typing import Annotated
-        import pandas as pd
-        from pydantic import BaseModel
-        from pydantic_extra_types.pandas import PandasDataFrameValidator
-
-        UserFrame = Annotated[pd.DataFrame, PandasDataFrameValidator(required_columns=['name', 'email'])]
-
-
-        class Model(BaseModel):
-            df: UserFrame
-
-
-        m = Model(df=pd.DataFrame({'name': ['Alice'], 'email': ['alice@example.com']}))
-        ```
-    """
-
-    required_columns: list[str] | None = None
-    """An optional list of column names that the DataFrame must contain."""
-
-    def __get_pydantic_core_schema__(
-        self, source: type[Any], handler: GetCoreSchemaHandler
-    ) -> core_schema.CoreSchema:
-        return core_schema.no_info_before_validator_function(
-            partial(
-                _validate_dataframe,
-                self.required_columns,
-            ),
-            core_schema.any_schema(),
-        )
-
-    @classmethod
-    def __get_pydantic_json_schema__(
-        cls, schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler
-    ) -> dict[str, Any]:
-        json_schema = handler(schema)
-        json_schema.update({'type': 'object', 'title': 'DataFrame'})
-        return json_schema
-
-    def __hash__(self) -> int:
-        return super().__hash__()
-
-
-def _validate_dataframe(
-    required_columns: list[str] | None,
-    value: Any,
-) -> pd.DataFrame:
-    """Validate that *value* is a ``pd.DataFrame`` and (optionally) that it
-    contains *required_columns*."""
-    if not isinstance(value, pd.DataFrame):
-        raise PydanticCustomError(
-            'value_error',
-            'value is not a valid pandas DataFrame',
-        )
-
-    if required_columns:
-        missing = [col for col in required_columns if col not in value.columns]
-        if missing:
-            raise PydanticCustomError(
-                'value_error',
-                'DataFrame is missing required columns: {}'.format(', '.join(missing)),
-            )
-
-    return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ all = [
     'tzdata>=2024.1',
     "cron-converter>=1.2.2",
     'uuid-utils>=0.6.0; python_version<"3.14"',
+    'pandas>=2.0.0,<4.0.0',
 ]
 phonenumbers = ['phonenumbers>=8,<10']
 pycountry = ['pycountry>=23']
@@ -69,6 +70,7 @@ python_ulid = [
 pendulum = ['pendulum>=3.0.0,<4.0.0']
 cron = ['cron-converter>=1.2.2']
 uuid_utils = ['uuid-utils>=0.6.0; python_version<"3.14"']
+pandas = ['pandas>=2.0.0,<4.0.0']
 
 [dependency-groups]
 dev = [

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -32,6 +32,7 @@ from pydantic_extra_types.ulid import ULID
 
 try:
     from pydantic_extra_types.pandas import PandasDataFrame, PandasSeries
+
     pandas_available = True
 except RuntimeError:
     pandas_available = False

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -30,6 +30,12 @@ from pydantic_extra_types.semver import _VersionPydanticAnnotation
 from pydantic_extra_types.timezone_name import TimeZoneName
 from pydantic_extra_types.ulid import ULID
 
+try:
+    from pydantic_extra_types.pandas import PandasDataFrame, PandasSeries
+    pandas_available = True
+except RuntimeError:
+    pandas_available = False
+
 languages = [lang.alpha_3 for lang in pycountry.languages]
 language_families = [lang.alpha_3 for lang in pycountry.language_families]
 languages.sort()
@@ -606,7 +612,41 @@ USNumberE164 = Annotated[
                 'required': ['x'],
             },
         ),
-    ],
+    ]
+    + (
+        [
+            (
+                PandasDataFrame,
+                {
+                    'title': 'Model',
+                    'type': 'object',
+                    'properties': {
+                        'x': {
+                            'title': 'DataFrame',
+                            'type': 'object',
+                        },
+                    },
+                    'required': ['x'],
+                },
+            ),
+            (
+                PandasSeries,
+                {
+                    'title': 'Model',
+                    'type': 'object',
+                    'properties': {
+                        'x': {
+                            'title': 'Series',
+                            'type': 'array',
+                        },
+                    },
+                    'required': ['x'],
+                },
+            ),
+        ]
+        if pandas_available
+        else []
+    ),
 )
 def test_json_schema(cls: Any, expected: dict[str, Any]) -> None:
     """Test the model_json_schema implementation for all extra types."""

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any
+from typing import Annotated
 
 import pandas as pd
 import pytest

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,162 @@
+from typing import Annotated, Any
+
+import pandas as pd
+import pytest
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from pydantic_extra_types.pandas import (
+    PandasDataFrame,
+    PandasDataFrameValidator,
+    PandasSeries,
+)
+
+
+class DataFrameModel(BaseModel):
+    df: PandasDataFrame
+
+
+class SeriesModel(BaseModel):
+    s: PandasSeries
+
+
+def test_valid_dataframe() -> None:
+    df = pd.DataFrame({'a': [1, 2, 3]})
+    result = DataFrameModel(df=df)
+    assert isinstance(result.df, pd.DataFrame)
+    assert result.df.equals(df)
+
+
+def test_invalid_dataframe_not_a_dataframe() -> None:
+    with pytest.raises(ValidationError, match='value is not a valid pandas DataFrame'):
+        DataFrameModel(df='not a dataframe')
+
+
+def test_invalid_dataframe_none() -> None:
+    with pytest.raises(ValidationError, match='value is not a valid pandas DataFrame'):
+        DataFrameModel(df=None)
+
+
+def test_invalid_dataframe_int() -> None:
+    with pytest.raises(ValidationError, match='value is not a valid pandas DataFrame'):
+        DataFrameModel(df=42)
+
+
+def test_valid_series() -> None:
+    s = pd.Series([1, 2, 3])
+    result = SeriesModel(s=s)
+    assert isinstance(result.s, pd.Series)
+    assert result.s.equals(s)
+
+
+def test_invalid_series_not_a_series() -> None:
+    with pytest.raises(ValidationError, match='value is not a valid pandas Series'):
+        SeriesModel(s='not a series')
+
+
+def test_invalid_series_none() -> None:
+    with pytest.raises(ValidationError, match='value is not a valid pandas Series'):
+        SeriesModel(s=None)
+
+
+def test_invalid_series_int() -> None:
+    with pytest.raises(ValidationError, match='value is not a valid pandas Series'):
+        SeriesModel(s=42)
+
+
+def test_empty_dataframe() -> None:
+    df = pd.DataFrame()
+    result = DataFrameModel(df=df)
+    assert isinstance(result.df, pd.DataFrame)
+
+
+def test_empty_series() -> None:
+    s = pd.Series(dtype='float64')
+    result = SeriesModel(s=s)
+    assert isinstance(result.s, pd.Series)
+
+
+def test_dataframe_with_multiple_columns() -> None:
+    df = pd.DataFrame({'name': ['Alice', 'Bob'], 'age': [30, 25]})
+    result = DataFrameModel(df=df)
+    assert list(result.df.columns) == ['name', 'age']
+
+
+class RequiredColumnsFrame(PandasDataFrame):
+    required_columns = ['name', 'email']
+
+
+class RequiredColumnsModel(BaseModel):
+    df: RequiredColumnsFrame
+
+
+def test_dataframe_with_required_columns_passes() -> None:
+    df = pd.DataFrame({'name': ['Alice'], 'email': ['alice@example.com']})
+    result = RequiredColumnsModel(df=df)
+    assert isinstance(result.df, pd.DataFrame)
+
+
+def test_dataframe_with_required_columns_fails() -> None:
+    df = pd.DataFrame({'name': ['Alice']})
+    with pytest.raises(ValidationError, match='missing required columns'):
+        RequiredColumnsModel(df=df)
+
+
+def test_dataframe_with_required_columns_multiple_missing() -> None:
+    df = pd.DataFrame({'foo': [1]})
+    with pytest.raises(ValidationError, match='missing required columns'):
+        RequiredColumnsModel(df=df)
+
+
+def test_dataframe_with_required_columns_extra_columns_allowed() -> None:
+    df = pd.DataFrame({'name': ['Alice'], 'email': ['alice@example.com'], 'age': [30]})
+    result = RequiredColumnsModel(df=df)
+    assert isinstance(result.df, pd.DataFrame)
+
+
+AnnotatedFrame = Annotated[
+    pd.DataFrame,
+    PandasDataFrameValidator(required_columns=['name', 'email']),
+]
+
+
+class AnnotatedModel(BaseModel):
+    df: AnnotatedFrame
+
+
+def test_annotated_validator_passes() -> None:
+    df = pd.DataFrame({'name': ['Alice'], 'email': ['alice@example.com']})
+    result = AnnotatedModel(df=df)
+    assert isinstance(result.df, pd.DataFrame)
+
+
+def test_annotated_validator_fails() -> None:
+    df = pd.DataFrame({'name': ['Alice']})
+    with pytest.raises(ValidationError, match='missing required columns'):
+        AnnotatedModel(df=df)
+
+
+def test_annotated_validator_not_a_dataframe() -> None:
+    with pytest.raises(ValidationError, match='value is not a valid pandas DataFrame'):
+        AnnotatedModel(df='not a dataframe')
+
+
+def test_type_adapter_dataframe() -> None:
+    adapter = TypeAdapter(PandasDataFrame)
+    df = pd.DataFrame({'x': [1]})
+    result = adapter.validate_python(df)
+    assert isinstance(result, pd.DataFrame)
+    assert result.equals(df)
+
+
+def test_type_adapter_dataframe_fails() -> None:
+    adapter = TypeAdapter(PandasDataFrame)
+    with pytest.raises(ValidationError, match='value is not a valid pandas DataFrame'):
+        adapter.validate_python(42)
+
+
+def test_type_adapter_series() -> None:
+    adapter = TypeAdapter(PandasSeries)
+    s = pd.Series([1, 2, 3])
+    result = adapter.validate_python(s)
+    assert isinstance(result, pd.Series)
+    assert result.equals(s)


### PR DESCRIPTION
Add support for validating pandas DataFrame and Series objects as Pydantic model fields.

Changes:
- Add PandasDataFrame type with optional required_columns validation
- Add PandasSeries type for Series validation
- Add PandasDataFrameValidator annotation for column-level constraints
- Register pandas as an optional dependency in pyproject.toml
- Add comprehensive test suite covering both types

Closes #64