### PR TITLE
Add JWTStr type for structural JWT validation

### DIFF
--- a/pydantic_extra_types/jwt.py
+++ b/pydantic_extra_types/jwt.py
@@ -91,7 +91,7 @@ class JWTStr(str):
             raise PydanticCustomError('jwt_type', 'Payload must be a JSON object')
 
         alg = header.get('alg')
-        if not alg or not isinstance(alg, str):
+        if not alg or not isinstance(alg, str) or alg.lower() == 'none':
             raise PydanticCustomError('jwt_format', 'Header must contain non-empty alg')
 
     @property

--- a/pydantic_extra_types/jwt.py
+++ b/pydantic_extra_types/jwt.py
@@ -54,7 +54,7 @@ class JWTStr(str):
 
     def __new__(cls, value: Any) -> JWTStr:
         cls._validate(value)
-        return cast('JWTStr', super().__new__(cls, value))
+        return super().__new__(cls, value)
 
     @classmethod
     def validate(cls, value: Any, _: core_schema.ValidationInfo) -> JWTStr:
@@ -97,12 +97,12 @@ class JWTStr(str):
     @property
     def header(self) -> dict[str, Any]:
         """Return the decoded JWT header."""
-        return json.loads(self._decode_segment(self.split('.')[0]).decode())
+        return cast('dict[str, Any]', json.loads(self._decode_segment(self.split('.')[0]).decode()))
 
     @property
     def payload(self) -> dict[str, Any]:
         """Return the decoded JWT payload."""
-        return json.loads(self._decode_segment(self.split('.')[1]).decode())
+        return cast('dict[str, Any]', json.loads(self._decode_segment(self.split('.')[1]).decode()))
 
     @property
     def signature(self) -> bytes:

--- a/pydantic_extra_types/jwt.py
+++ b/pydantic_extra_types/jwt.py
@@ -1,0 +1,115 @@
+"""The `pydantic_extra_types.jwt` module provides the [`JWTStr`][pydantic_extra_types.jwt.JWTStr] data type.
+
+This class depends on the `pydantic` package and implements structural validation of JWT format (RFC 7519). It does not verify the cryptographic signature.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from typing import Any, cast
+
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic_core import PydanticCustomError, core_schema
+
+
+class JWTStr(str):
+    """A string subclass with structural validation for JWT (JSON Web Token) format.
+
+        ## Examples
+    ```python
+        from pydantic import BaseModel
+
+        from pydantic_extra_types.jwt import JWTStr
+
+
+        class Auth(BaseModel):
+            token: JWTStr
+
+
+        auth = Auth(token='eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA')
+        print(auth.token.header)
+        #> {'alg': 'HS256'}
+        print(auth.token.payload)
+        #> {'sub': '1234567890'}
+        print(auth.token.signature)
+        #> b'test'
+    ```
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        return core_schema.with_info_after_validator_function(cls.validate, core_schema.str_schema())
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> dict[str, Any]:
+        json_schema = handler(schema)
+        json_schema.update(
+            {'type': 'string', 'format': 'jwt', 'examples': ['eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA']}
+        )
+        return json_schema
+
+    def __new__(cls, value: Any) -> JWTStr:
+        cls._validate(value)
+        return cast('JWTStr', super().__new__(cls, value))
+
+    @classmethod
+    def validate(cls, value: Any, _: core_schema.ValidationInfo) -> JWTStr:
+        """Validate and construct a JWTStr from the provided value."""
+        return cls(value)
+
+    @classmethod
+    def _validate(cls, value: Any) -> None:
+        if not isinstance(value, str):
+            raise PydanticCustomError('jwt_type', 'Value must be a string')
+
+        parts = value.split('.')
+        if len(parts) != 3:
+            raise PydanticCustomError(
+                'jwt_format', 'Value must include header, payload, and signature separated by dots'
+            )
+
+        try:
+            header_bytes = cls._decode_segment(parts[0])
+            payload_bytes = cls._decode_segment(parts[1])
+            cls._decode_segment(parts[2])  # signature
+        except (ValueError, binascii.Error):
+            raise PydanticCustomError('jwt_format', 'Headers, payload and signature must be valid urlsafe base64')
+
+        try:
+            header = json.loads(header_bytes.decode())
+            payload = json.loads(payload_bytes.decode())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise PydanticCustomError('jwt_format', 'Header and payload must be valid JSON')
+
+        if not isinstance(header, dict):
+            raise PydanticCustomError('jwt_type', 'Header must be a JSON object')
+        if not isinstance(payload, dict):
+            raise PydanticCustomError('jwt_type', 'Payload must be a JSON object')
+
+        alg = header.get('alg')
+        if not alg or not isinstance(alg, str):
+            raise PydanticCustomError('jwt_format', 'Header must contain non-empty alg')
+
+    @property
+    def header(self) -> dict[str, Any]:
+        """Return the decoded JWT header."""
+        return json.loads(self._decode_segment(self.split('.')[0]).decode())
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        """Return the decoded JWT payload."""
+        return json.loads(self._decode_segment(self.split('.')[1]).decode())
+
+    @property
+    def signature(self) -> bytes:
+        """Return the raw JWT signature bytes."""
+        return self._decode_segment(self.split('.')[2])
+
+    @staticmethod
+    def _decode_segment(segment: str) -> bytes:
+        padded = segment + '=' * (-len(segment) % 4)
+        return base64.b64decode(padded, altchars=b'-_', validate=True)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,0 +1,80 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+from pydantic_core import PydanticCustomError
+
+from pydantic_extra_types.jwt import JWTStr
+
+
+class JWTTest(BaseModel):
+    token: JWTStr
+
+
+@pytest.mark.parametrize(
+    'jwt, valid',
+    [
+        (
+            'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA',
+            True,
+        ),
+        (
+            123456789,  # not a string
+            False,
+        ),
+        (
+            'invalid_jwt',  # no dots, not 3 parts
+            False,
+        ),
+        (
+            '!!!.eyJhbGciOiJIUzI1NiJ9.dGVzdA',  # invalid base64url characters
+            False,
+        ),
+        (
+            'eyJhbGciOiJIUzI1NiJ9+.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA',  # contains standard base64 char '+', not urlsafe
+            False,
+        ),
+        (
+            'invalid_b64.invalid_b64.invalid_b64',  # valid base64url, but not valid UTF-8/JSON
+            False,
+        ),
+        (
+            'aW52YWxpZF9qc29u.aW52YWxpZF9qc29u.aW52YWxpZF9qc29u',  # invalid JSON
+            False,
+        ),
+        (
+            'Njc.Njc.Njc',  # valid JSON, but not a dict
+            False,
+        ),
+        (
+            'eyJhbGciOiJIUzI1NiJ9.Njc.Njc',  # valid JSON, but not a dict
+            False,
+        ),
+        (
+            'e30.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA',  # alg is missed in header
+            False,
+        ),
+    ],
+)
+def test_jwt(jwt: str, valid: bool):
+    if valid:
+        assert JWTTest(token=jwt).token == jwt
+        assert JWTStr(jwt) == jwt
+    else:
+        with pytest.raises(ValidationError):
+            JWTTest(token=jwt)
+        with pytest.raises(PydanticCustomError):
+            JWTStr(jwt)
+
+
+def test_jwt_params():
+    auth = JWTTest(token='eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA')
+    assert auth.token.header == {'alg': 'HS256'}
+    assert auth.token.payload == {'sub': '1234567890'}
+    assert auth.token.signature == b'test'
+
+
+def test_jwt_json_schema():
+    schema = JWTTest.model_json_schema()
+    token_schema = schema['properties']['token']
+    assert token_schema['type'] == 'string'
+    assert token_schema['format'] == 'jwt'
+    assert token_schema['examples'] == ['eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA']

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -52,6 +52,10 @@ class JWTTest(BaseModel):
             'e30.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA',  # alg is missed in header
             False,
         ),
+        (
+            'eyJhbGciOiAibm9uZSJ9.eyJhbGciOiAibm9uZSJ9.eyJhbGciOiAibm9uZSJ9', # alg is none
+            False,
+        ),
     ],
 )
 def test_jwt(jwt: str, valid: bool):


### PR DESCRIPTION
## Summary

Adds `JWTStr`, a `str` subclass that performs structural validation of JSON
Web Tokens (JWT, RFC 7519).

## Motivation

I'm working on a personal project that needed safe structural validation of
JWT format before handing tokens off for actual signature verification.
I couldn't find a built-in type for this in `pydantic-extra-types`, so I
decided to add one myself. This is my first contribution to a pydantic
project, so feedback on the approach is very welcome.

## What is validated

- The value has exactly three dot-separated parts (header, payload, signature)
- Header and payload are valid urlsafe-base64-encoded JSON objects
- The header contains a non-empty `alg`
- The signature is valid urlsafe base64 (its cryptographic correctness is not checked)

## What is NOT validated

Signature verification is intentionally out of scope — it requires a secret
or key that this type has no access to. Verifying the signature is left to
the library the user chooses for that (e.g. `pyjwt`, `python-jose`, `authlib`).

## API

`JWTStr` exposes the decoded parts as properties:

```python
from pydantic import BaseModel
from pydantic_extra_types.jwt import JWTStr

class Auth(BaseModel):
    token: JWTStr

auth = Auth(token='eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdA')
auth.token.header      # {'alg': 'HS256'}
auth.token.payload     # {'sub': '1234567890'}
auth.token.signature   # b'test'
```

Validation runs both through the pydantic core schema and in `__new__`, so
`JWTStr(...)` is validated the same way whether it's constructed directly or
through a pydantic model.

## Tests

Added `tests/test_jwt.py` covering valid/invalid structure, invalid
base64url, invalid JSON, non-dict header/payload, missing `alg`, and the
generated JSON schema.