### PR TITLE
Fix MacAddress accepting octets with a sign or whitespace

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## Latest Changes
 
+* fix(mac_address): reject MAC octets with a sign or whitespace (e.g. `-a:...`, `+a:...`, ` a:...`) that `int(..., 16)` accepted.
+
 ## 2.11.2
 
 * fix: accept common timezone abbreviations like EDT in TimeZoneName validator by @r266-tech in https://github.com/pydantic/pydantic-extra-types/pull/376

--- a/pydantic_extra_types/mac_address.py
+++ b/pydantic_extra_types/mac_address.py
@@ -4,6 +4,7 @@ formats, such as IEEE 802 MAC-48, EUI-48, EUI-64, or a 20-octet format.
 
 from __future__ import annotations
 
+import string
 from typing import Any
 
 from pydantic import GetCoreSchemaHandler
@@ -100,7 +101,12 @@ class MacAddress(str):
                 mac_bytes: list[int] = []
                 for part in parts:
                     for i in range(0, chunk_len, 2):
-                        mac_bytes.append(int(part[i : i + 2], base=16))
+                        octet = part[i : i + 2]
+                        # int(octet, 16) also accepts a sign or whitespace,
+                        # which are not valid MAC octets.
+                        if not all(char in string.hexdigits for char in octet):
+                            raise ValueError(octet)
+                        mac_bytes.append(int(octet, base=16))
             except ValueError as exc:
                 raise PydanticCustomError('mac_address_format', 'Unrecognized format') from exc
 

--- a/tests/test_mac_address.py
+++ b/tests/test_mac_address.py
@@ -56,6 +56,11 @@ class Network(BaseModel):
         ('00.00.5e.00.53.01.', None, False),  # Extra separator at the end
         ('00:00:5e:00:53:', None, False),  # Incomplete MAC address
         (float(12345678910111213), None, False),
+        # int(..., 16) accepts a sign or whitespace; a MAC octet must not.
+        ('-a:-b:-c:-d:-e:-f', None, False),
+        ('+a:+b:+c:+d:+e:+f', None, False),
+        (' a: b: c: d: e: f', None, False),
+        ('-aaa.-bbb.-ccc', None, False),
     ],
 )
 def test_format_for_mac_address(mac_address: Any, result: str, valid: bool):


### PR DESCRIPTION

## Problem

`MacAddress` accepts strings that are not valid MAC addresses when an octet
contains a leading sign or surrounding whitespace:

```python
from pydantic import BaseModel
from pydantic_extra_types.mac_address import MacAddress

class N(BaseModel):
    m: MacAddress

N(m="-a:-b:-c:-d:-e:-f").m   # '-a:-b:-c:-d:-e:-f'   (accepted)
N(m="+a:+b:+c:+d:+e:+f").m   # '0a:0b:0c:0d:0e:0f'   (accepted, silently normalized)
N(m=" a: b: c: d: e: f").m   # '0a:0b:0c:0d:0e:0f'   (accepted, silently normalized)
```

A MAC octet must be exactly two hexadecimal digits. The `+`/whitespace cases
are especially bad: the input is silently "cleaned up" into a valid-looking
MAC that the caller never provided.

## Root cause

`pydantic_extra_types/mac_address.py`, `MacAddress.validate_mac_address`
parses each octet with `int(part[i:i+2], base=16)`. Python's `int()` with a
base accepts a leading `+`/`-` sign and surrounding ASCII whitespace, so
`int("-a", 16)`, `int("+a", 16)` and `int(" a", 16)` all succeed instead of
raising `ValueError`. The chunk-length checks above only constrain the number
of characters, not that each character is a hex digit, so these malformed
octets pass through.

## Fix

Before converting an octet, require that both characters are hex digits
(`string.hexdigits`). Non-hex characters now raise `ValueError`, which the
existing `except ValueError` turns into the `mac_address_format` error, exactly
like other malformed octets (e.g. `00:00:5g:00:53:01`).

## Test

`tests/test_mac_address.py::test_format_for_mac_address` gains cases for
sign/whitespace octets in both the `:`/`-` and `.` formats, asserting they
raise a validation error whose message matches `format`. They fail on the
current `main` (`Failed: DID NOT RAISE ValidationError`) and pass with the fix.
